### PR TITLE
Update 05 data-parameterization.md

### DIFF
--- a/src/data/markdown/docs/05 Examples/01 Examples/05 data-parameterization.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/05 data-parameterization.md
@@ -54,11 +54,11 @@ import { SharedArray } from "k6/data";
 // not using SharedArray here will mean that the code in the function call (that is what loads and
 // parses the json) will be executed per each VU which also means that there will be a complete copy
 // per each VU
-const data = new SharedArray("some data name", function() { return JSON.parse(open('./data.json')); });
+const data = new SharedArray("some data name", function() { return JSON.parse(open('./data.json')).users; });
 
 export default function () {
-  let user = data.users[0];
-  console.log(data.users[0].username);
+  let user = data[0];
+  console.log(data[0].username);
 }
 ```
 


### PR DESCRIPTION
### Description

The current code snippet throws an error. It implies SharedArray can only contain/parse Arrays. Hence reading `users` property on the Object to return array directly.

`ERRO[0000] GoError: only arrays can be made into SharedArray at apply (native)`