### PR TITLE
Update 08 Tags and Groups.md

### DIFF
--- a/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
@@ -222,7 +222,7 @@ export let options = {
 
 </CodeGroup>
 
-Read more about the [k6 results output syntax](/getting-started/results-output/json) to
+Read more about the [k6 results output syntax](/results-visualization/json) to
 see how tags affect your test result output.
 
 ## Tags and Groups in k6 Cloud Results


### PR DESCRIPTION
If the link is clicked from the page itself, it does not invoke a redirect and instead leads to a 404, whereas if the link is opened in a new tab, the redirect *does* kick in. Updated the link so that the user is navigated to the correct page straight away, removing the 404 and the need to redirect.