### PR TITLE
Add docs for `http_req_failed`

### DIFF
--- a/src/data/markdown/docs/01 guides/02 Using k6/01 HTTP requests.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/01 HTTP requests.md
@@ -67,8 +67,11 @@ k6 will automatically apply [tags](/using-k6/tags-and-groups#section-tags) to yo
 
 | Name   | Description                                |
 | ------ | ------------------------------------------ |
+| expected_response    | By default, response statuses between 200 and 399 are `true`. Change the default behavior with [setResponseCallback](/javascript-api/k6-http/setresponsecallback-callback).                  |
+| group   | When the request runs inside a [group](/javascript-api/k6/group-name-fn), the tag value is the group name.  Default is empty.               |
 | name   | Defaults to URL requested                  |
 | method | Request method (`GET`, `POST`, `PUT` etc.) |
+| scenario   | When the request runs inside a [scenario](/using-k6/scenarios), the tag value is the scenario name.  Default is empty.               |
 | status | response status                            |
 | url    | defaults to URL requested                  |
 
@@ -84,9 +87,11 @@ Below you can see how a test result data point (the duration of an HTTP request)
     "time": "2017-06-02T23:10:29.52444541+02:00",
     "value": 586.831127,
     "tags": {
+      "expected_response": "true",
       "group": "",
       "method": "GET",
       "name": "http://test.k6.io",
+      "scenario": "",
       "status": "200",
       "url": "http://test.k6.io"
     }
@@ -144,7 +149,6 @@ Which would produce JSON output like the following:
         "time":"2017-06-02T23:10:29.52444541+02:00",
         "value":586.831127,
         "tags": {
-            "group":"",
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
@@ -162,7 +166,6 @@ Which would produce JSON output like the following:
         "time":"2017-06-02T23:10:29.58582529+02:00",
         "value":580.839273,
         "tags": {
-            "group":"",
             "method":"GET",
             "name":"PostsItemURL",
             "status":"200",
@@ -176,7 +179,7 @@ Which would produce JSON output like the following:
 
 Note how the `name` is the same for the two data samples related to two different URLs. Filtering the results on tag `name: PostsItemURL` will give you a result set including all the data points from all the 100 different URLs.
 
-Additionally, you can use the `http.url` (v0.16.0) wrapper to set the name tag with a string template value:
+Additionally, you can use the `http.url` wrapper to set the name tag with a string template value:
 
 <CodeGroup labels={[ ]} lineNumbers={[true]}>
 

--- a/src/data/markdown/docs/01 guides/02 Using k6/01 HTTP requests.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/01 HTTP requests.md
@@ -67,7 +67,7 @@ k6 will automatically apply [tags](/using-k6/tags-and-groups#section-tags) to yo
 
 | Name   | Description                                |
 | ------ | ------------------------------------------ |
-| expected_response    | By default, response statuses between 200 and 399 are `true`. Change the default behavior with [setResponseCallback](/javascript-api/k6-http/setresponsecallback-callback).                  |
+| expected_response <sup>(≥ v0.31)</sup>  | By default, response statuses between 200 and 399 are `true`. Change the default behavior with [setResponseCallback](/javascript-api/k6-http/setresponsecallback-callback).                  |
 | group   | When the request runs inside a [group](/javascript-api/k6/group-name-fn), the tag value is the group name.  Default is empty.               |
 | name   | Defaults to URL requested                  |
 | method | Request method (`GET`, `POST`, `PUT` etc.) |

--- a/src/data/markdown/docs/01 guides/02 Using k6/02 Metrics.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/02 Metrics.md
@@ -17,14 +17,14 @@ The following _built-in_ metrics will **always** be collected by k6:
 
 | Metric Name          | Type    | Description                                                                                                                                                                                                     |
 | -------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `vus`                | Gauge   | Current number of active virtual users                                                                                                                                                                          |
-| `vus_max`            | Gauge   | Max possible number of virtual users (VU resources are pre-allocated, to ensure performance will not be affected when scaling up the load level)                                                                |
-| `iterations`         | Counter | The aggregate number of times the VUs in the test have executed the JS script (the `default` function).                                                                                                         |
-| `iteration_duration` | Trend   | The time it took to complete one full iteration of the default/main function.                                                                                                                                   |
-| `dropped_iterations` | Counter | Introduced in k6 v0.27.0, the number of iterations that could not be started due to lack of VUs (for the arrival-rate executors) or lack of time (due to expired maxDuration in the iteration-based executors). |
-| `data_received`      | Counter | The amount of received data. Read [this example](/examples/track-transmitted-data-per-url) to track data for an individual URL.                                                                                 |
-| `data_sent`          | Counter | The amount of data sent. Read [this example](/examples/track-transmitted-data-per-url) to track data for an individual URL.                                                                                     |
-| `checks`             | Rate    | The rate of successful checks.                                                                                                                                                                                  |
+| vus                | Gauge   | Current number of active virtual users                                                                                                                                                                          |
+| vus_max            | Gauge   | Max possible number of virtual users (VU resources are pre-allocated, to ensure performance will not be affected when scaling up the load level)                                                                |
+| iterations         | Counter | The aggregate number of times the VUs in the test have executed the JS script (the `default` function).                                                                                                         |
+| iteration_duration | Trend   | The time it took to complete one full iteration of the default/main function.                                                                                                                                   |
+| dropped_iterations | Counter | Introduced in k6 v0.27.0, the number of iterations that could not be started due to lack of VUs (for the arrival-rate executors) or lack of time (due to expired maxDuration in the iteration-based executors). |
+| data_received      | Counter | The amount of received data. Read [this example](/examples/track-transmitted-data-per-url) to track data for an individual URL.                                                                                 |
+| data_sent          | Counter | The amount of data sent. Read [this example](/examples/track-transmitted-data-per-url) to track data for an individual URL.                                                                                     |
+| checks             | Rate    | The rate of successful checks.                                                                                                                                                                                  |
 
 ## HTTP-specific built-in metrics
 
@@ -32,14 +32,15 @@ _built-in_ metrics will only be generated when/if HTTP requests are made:
 
 | Metric Name                | Type    | Description                                                                                                                                                                                                                                  |
 | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `http_reqs`                | Counter | How many HTTP requests has k6 generated, in total.                                                                                                                                                                                           |
-| `http_req_blocked`         | Trend   | Time spent blocked (waiting for a free TCP connection slot) before initiating the request. `float`                                                                                                                                           |
-| `http_req_connecting`      | Trend   | Time spent establishing TCP connection to the remote host. `float`                                                                                                                                                                           |
-| `http_req_tls_handshaking` | Trend   | Time spent handshaking TLS session with remote host                                                                                                                                                                                          |
-| `http_req_sending`         | Trend   | Time spent sending data to the remote host. `float`                                                                                                                                                                                          |
-| `http_req_waiting`         | Trend   | Time spent waiting for response from remote host (a.k.a. \"time to first byte\", or \"TTFB\"). `float`                                                                                                                                       |
-| `http_req_receiving`       | Trend   | Time spent receiving response data from the remote host. `float`                                                                                                                                                                             |
-| `http_req_duration`        | Trend   | Total time for the request. It's equal to `http_req_sending + http_req_waiting + http_req_receiving` (i.e. how long did the remote server take to process the request and respond, without the initial DNS lookup/connection times). `float` |
+| http_reqs                | Counter | How many HTTP requests has k6 generated, in total.                                                                                                                                                                                           |
+| http_req_blocked         | Trend   | Time spent blocked (waiting for a free TCP connection slot) before initiating the request. `float`                                                                                                                                           |
+| http_req_connecting      | Trend   | Time spent establishing TCP connection to the remote host. `float`                                                                                                                                                                           |
+| http_req_tls_handshaking | Trend   | Time spent handshaking TLS session with remote host                                                                                                                                                                                          |
+| http_req_sending         | Trend   | Time spent sending data to the remote host. `float`                                                                                                                                                                                          |
+| http_req_waiting         | Trend   | Time spent waiting for response from remote host (a.k.a. \"time to first byte\", or \"TTFB\"). `float`                                                                                                                                       |
+| http_req_receiving       | Trend   | Time spent receiving response data from the remote host. `float`                                                                                                                                                                             |
+| http_req_duration        | Trend   | Total time for the request. It's equal to `http_req_sending + http_req_waiting + http_req_receiving` (i.e. how long did the remote server take to process the request and respond, without the initial DNS lookup/connection times). `float` |
+| http_req_failed <sup>(≥ v0.31)</sup> | Rate |  The rate of failed requests according to [setResponseCallback](/javascript-api/k6-http/setresponsecallback-callback). | 
 
 ### Accessing HTTP timings from a script
 
@@ -61,17 +62,17 @@ In the above snippet, `res` is an [HTTP Response](/javascript-api/k6-http/respon
 
 | Property                      | Description                                                           |
 | ----------------------------- | --------------------------------------------------------------------- |
-| `res.body`                    | `string` containing the HTTP response body                            |
-| `res.headers`                 | `object` containing header-name/header-value pairs                    |
-| `res.status`                  | `integer` containing HTTP response code received from server          |
-| `res.timings`                 | `object` containing HTTP timing information for the request in **ms** |
-| `res.timings.blocked`         | = `http_req_blocked`                                                  |
-| `res.timings.connecting`      | = `http_req_connecting`                                               |
-| `res.timings.tls_handshaking` | = `http_req_tls_handshaking`                                          |
-| `res.timings.sending`         | = `http_req_sending`                                                  |
-| `res.timings.waiting`         | = `http_req_waiting`                                                  |
-| `res.timings.receiving`       | = `http_req_receiving`                                                |
-| `res.timings.duration`        | = `http_req_duration`                                                 |
+| res.body                    | `string` containing the HTTP response body                            |
+| res.headers                 | `object` containing header-name/header-value pairs                    |
+| res.status                  | `integer` containing HTTP response code received from server          |
+| res.timings                 | `object` containing HTTP timing information for the request in **ms** |
+| res.timings.blocked         | = `http_req_blocked`                                                  |
+| res.timings.connecting      | = `http_req_connecting`                                               |
+| res.timings.tls_handshaking | = `http_req_tls_handshaking`                                          |
+| res.timings.sending         | = `http_req_sending`                                                  |
+| res.timings.waiting         | = `http_req_waiting`                                                  |
+| res.timings.receiving       | = `http_req_receiving`                                                |
+| res.timings.duration        | = `http_req_duration`                                                 |
 
 ## Custom metrics
 

--- a/src/data/markdown/docs/01 guides/02 Using k6/04 Thresholds.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/04 Thresholds.md
@@ -95,7 +95,7 @@ import { sleep } from 'k6';
 export let options = {
   thresholds: {
     // During the whole test execution, the error rate must be lower than 1%.
-    // `http_req_failed` metric is available since 0.31
+    // `http_req_failed` metric is available since v0.31.0
     http_req_failed: ['rate<0.01'],
   },
 };

--- a/src/data/markdown/docs/01 guides/02 Using k6/04 Thresholds.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/04 Thresholds.md
@@ -53,7 +53,7 @@ When executing that script, k6 will output something similar to this:
 ```
 </CodeGroup>
 
-- In the above case, criteria for both thresholds were met. The whole load test is considered
+- In the above case, the criteria for both thresholds were met. The whole load test is considered
   to be a `pass`, which means that k6 will exit with exit code zero.
 
 - If any of the thresholds had failed, the little green checkmark <span style="color:green; font-weight:bold">✓</span> next to the threshold name

--- a/src/data/markdown/docs/01 guides/02 Using k6/04 Thresholds.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/04 Thresholds.md
@@ -1,6 +1,6 @@
 ---
 title: 'Thresholds'
-excerpt: ''
+excerpt: 'Thresholds are a pass/fail criteria used to specify the performance expectations of the system under test.'
 ---
 
 ## What are thresholds?
@@ -9,56 +9,55 @@ Thresholds are a pass/fail criteria used to specify the performance expectations
 
 Example expectations (Thresholds):
 
-- System doesn't produce more than 1% errors
+- System doesn't produce more than 1% errors.
 - Response time for 95% of requests should be below 200ms.
 - Response time for 99% of requests should be below 400ms.
 - Specific endpoint must always respond within 300ms.
+- Any conditions on any [Custom metric](/using-k6/metrics#custom-metrics).
 
 Thresholds analyze the performance metrics and determine the final test result (pass/fail).
 Thresholds are a essential for [load-testing automation](/testing-guides/automated-performance-testing).
 
-Here is a sample script that specifies two thresholds, one using a custom [Rate metric](/javascript-api/k6-metrics/rate), and one using a standard `http_req_duration` metric.
+Here is a sample script that specifies two thresholds, one evaluating the rate of http errors (`http_req_failed` metric) and one using the 95 percentile of all the response durations (the `http_req_duration` metric).
 
 <CodeGroup labels={["threshold.js"]} lineNumbers={[true]}>
 
 ```javascript
 import http from 'k6/http';
-import { Rate } from 'k6/metrics';
-
-const myFailRate = new Rate('failed requests');
 
 export let options = {
   thresholds: {
-    'failed requests': ['rate<0.1'], // threshold on a custom metric
-    http_req_duration: ['p(95)<500'], // threshold on a standard metric
+    http_req_failed: ['rate<0.01'],   // http errors should be less than 1% 
+    http_req_duration: ['p(95)<500'], // 95% of requests should be below 200ms
   },
 };
 
 export default function () {
-  let res = http.get('https://test-api.k6.io/public/crocodiles/1/');
-  myFailRate.add(res.status !== 200);
+  http.get('https://test-api.k6.io/public/crocodiles/1/');
 }
 ```
 
 </CodeGroup>
 
-The `failed requests` threshold specifies that we want our load test to be considered a failure
-(resulting in k6 exiting with a non-zero exit code) if 10% or more of requests resulted in the server
-returning anything else than a 200-response. The `http_req_duration` threshold specifies that
-95% of requests must complete within 500ms.
-
 In other words, you specify the `pass` criteria when defining your threshold, and if that
 expression evaluates to `false` at the end of the test, the whole test will be considered a `fail`.
 
 When executing that script, k6 will output something similar to this:
-![executing k6 with a threshold](images/Thresholds/executing-with-a-threshold.png)
+
+<CodeGroup labels={["threshold-output"]} lineNumbers={[false]}>
+
+```bash
+   ✓ http_req_duration..............: avg=151.06ms min=151.06ms med=151.06ms max=151.06ms p(90)=151.06ms p(95)=151.06ms
+       { expected_response:true }...: avg=151.06ms min=151.06ms med=151.06ms max=151.06ms p(90)=151.06ms p(95)=151.06ms
+   ✓ http_req_failed................: 0.00%  ✓ 0 ✗ 1
+```
+</CodeGroup>
 
 - In the above case, criteria for both thresholds were met. The whole load test is considered
   to be a `pass`, which means that k6 will exit with exit code zero.
 
-- If any of the thresholds had failed, the little green checkmark
-  <span style="color:green; font-weight:bold">✓</span> next to the threshold name
-  (`failed requests`, `http_req_duration`) would have been a red cross <span style="color:red; font-weight:bold">✗</span> instead, and k6 would have generated a non-zero exit code.
+- If any of the thresholds had failed, the little green checkmark <span style="color:green; font-weight:bold">✓</span> next to the threshold name
+  (`http_req_failed`, `http_req_duration`) would have been a red cross <span style="color:red; font-weight:bold">✗</span> instead, and k6 would have generated a non-zero exit code.
 
 ## Copy-paste Threshold examples
 
@@ -80,7 +79,29 @@ export let options = {
 };
 
 export default function () {
-  let res1 = http.get('https://test-api.k6.io/public/crocodiles/1/');
+  http.get('https://test-api.k6.io/public/crocodiles/1/');
+  sleep(1);
+}
+```
+
+</CodeGroup>
+
+<CodeGroup labels={["threshold-error-rate.js"]} lineNumbers={[true]}>
+
+```javascript
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export let options = {
+  thresholds: {
+    // During the whole test execution, the error rate must be lower than 1%.
+    // `http_req_failed` metric is available since 0.31
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+export default function () {
+  http.get('https://test-api.k6.io/public/crocodiles/1/');
   sleep(1);
 }
 ```


### PR DESCRIPTION
[v0.31.0](https://github.com/loadimpact/k6/releases/tag/v0.31.0) introduced the `http_req_failed` metric.

This PR adds some basic documentation. Let me know if you think we should give a more detailed explanation or new examples.

