### PR TITLE
Add language filter to algolia search

### DIFF
--- a/src/components/shared/search-box/search-box.view.js
+++ b/src/components/shared/search-box/search-box.view.js
@@ -1,10 +1,12 @@
 import algoliasearch from 'algoliasearch/lite';
 import classNames from 'classnames';
 import { Heading } from 'components/shared/heading';
+import { useLocale } from 'contexts/locale-provider';
 import React, { useState, useEffect, useRef } from 'react';
 import {
   InstantSearch,
   Index,
+  Configure,
   connectStateResults,
   connectHits,
 } from 'react-instantsearch-dom';
@@ -65,6 +67,9 @@ export const SearchBox = ({ inputLabel, indices }) => {
   ) {
     return null;
   }
+
+  const { locale } = useLocale();
+
   const rootRef = useRef(null);
   const [query, setQuery] = useState('');
   const [focus, setFocus] = useState(false);
@@ -85,6 +90,7 @@ export const SearchBox = ({ inputLabel, indices }) => {
         placeholder={'Search'}
         showReset
       >
+        <Configure filters={locale} />
         <Input
           label={inputLabel}
           queryLength={query.length}

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -51,6 +51,15 @@ const processMdxEntry = (
     SUPPORTED_LOCALES.find((locale) => path.startsWith(`/${locale}/`)) ||
     DEFAULT_LOCALE;
 
+  const isNotGuidesPage = !(path.startsWith('/en/') || path.startsWith('/es/'));
+
+  let pageTags = [pageLocale];
+
+  // non-guides page should searchable in both ES and EN
+  if (isNotGuidesPage) {
+    pageTags = ['en', 'es'];
+  }
+
   const slug =
     pageLocale === DEFAULT_LOCALE
       ? getSlug(path)
@@ -67,6 +76,7 @@ const processMdxEntry = (
       objectID: `${objectID}-${pointer}`,
       slug: pageSlug.startsWith('/') ? pageSlug : `/${pageSlug}`,
       content: chunks[pointer],
+      _tags: pageTags,
     };
   }
   return cache;
@@ -134,7 +144,7 @@ const settings = {
   distinct: true,
 };
 
-const indexName = process.env.GATSBY_ALGOLIA_INDEX_NAME || 'test-setup';
+const indexName = process.env.GATSBY_ALGOLIA_INDEX_NAME || 'k6_docs';
 
 const queries = [
   {


### PR DESCRIPTION
This PR adds language filter to algolia search.
Depending on selected language, user will see search results for guides only in the chosen language.