### PR TITLE
Rollback redirect to translation

### DIFF
--- a/src/components/pages/doc-welcome/features/doc-welcome-features.view.js
+++ b/src/components/pages/doc-welcome/features/doc-welcome-features.view.js
@@ -1,6 +1,7 @@
 import { Heading } from 'components/shared/heading';
 import { Trait } from 'components/shared/trait';
 import { useI18n } from 'contexts/i18n-provider';
+import { useLocale } from 'contexts/locale-provider';
 import { Link } from 'gatsby';
 import React from 'react';
 
@@ -8,6 +9,7 @@ import styles from './doc-welcome-features.module.scss';
 
 export const Features = () => {
   const { t } = useI18n();
+  const { urlLocale } = useLocale();
 
   return (
     <section className={`container ${styles.container}`}>
@@ -24,16 +26,37 @@ export const Features = () => {
 
           <Trait className={styles.trait}>
             {t('welcome.features.scripting')}{' '}
-            <Link className={'link'} to="/using-k6/modules/">
+            <Link
+              className={'link'}
+              to={
+                urlLocale === 'es'
+                  ? '/es/usando-k6/modulos/'
+                  : '/using-k6/modules/'
+              }
+            >
               {t('welcome.features.modules')}
             </Link>
           </Trait>
           <Trait className={styles.trait}>
-            <Link className={'link'} to="/using-k6/checks/">
+            <Link
+              className={'link'}
+              to={
+                urlLocale === 'es'
+                  ? '/es/usando-k6/checks/'
+                  : '/using-k6/checks/'
+              }
+            >
               {t('welcome.features.checks')}
             </Link>{' '}
             {t('welcome.features.and')}{' '}
-            <Link className={'link'} to="/using-k6/thresholds/">
+            <Link
+              className={'link'}
+              to={
+                urlLocale === 'es'
+                  ? '/es/usando-k6/thresholds/'
+                  : '/using-k6/thresholds/'
+              }
+            >
               {t('welcome.features.thresholds')}
             </Link>{' '}
             {t('welcome.features.testing')}

--- a/src/components/pages/doc-welcome/k6-does-not/k6-does-not.component.js
+++ b/src/components/pages/doc-welcome/k6-does-not/k6-does-not.component.js
@@ -1,5 +1,6 @@
 import { Heading } from 'components/shared/heading';
 import { useI18n } from 'contexts/i18n-provider';
+import { useLocale } from 'contexts/locale-provider';
 import { Link } from 'gatsby';
 import React from 'react';
 
@@ -7,6 +8,7 @@ import styles from './k6-does-not.module.scss';
 
 export const K6DoesNot = () => {
   const { t } = useI18n();
+  const { urlLocale } = useLocale();
 
   return (
     <section className={`container ${styles.container}`}>
@@ -24,12 +26,23 @@ export const K6DoesNot = () => {
             {t('welcome.k6-does-not.browser.testing.text')}{' '}
             <Link
               className={'link'}
-              to="/testing-guides/load-testing-websites/"
+              to={
+                urlLocale === 'es'
+                  ? '/es/guias-de-prueba/pruebas-de-carga-a-sitios-web/'
+                  : '/testing-guides/load-testing-websites/'
+              }
             >
               {t('welcome.k6-does-not.browser.testing.link')}
             </Link>
             . {t('welcome.k6-does-not.browser.recorded-session.text')}{' '}
-            <Link className={'link'} to="/test-authoring/recording-a-session/">
+            <Link
+              className={'link'}
+              to={
+                urlLocale === 'es'
+                  ? '/es/creacion-de-pruebas/grabar-una-sesion/'
+                  : '/test-authoring/recording-a-session/'
+              }
+            >
               {t('welcome.k6-does-not.browser.recorded-session.link')}
             </Link>
             .
@@ -44,7 +57,11 @@ export const K6DoesNot = () => {
             {t('welcome.k6-does-not.nodejs.import.text1')}{' '}
             <Link
               className={'link'}
-              to="/using-k6/modules/#bundling-node-modules"
+              to={
+                urlLocale === 'es'
+                  ? '/es/usando-k6/modulos/#bundling-node-modules'
+                  : '/using-k6/modules/#bundling-node-modules'
+              }
             >
               {t('welcome.k6-does-not.nodejs.import.link')}
             </Link>{' '}

--- a/src/components/pages/doc-welcome/quickstart/quickstart.component.js
+++ b/src/components/pages/doc-welcome/quickstart/quickstart.component.js
@@ -1,4 +1,5 @@
 import { useI18n } from 'contexts/i18n-provider';
+import { useLocale } from 'contexts/locale-provider';
 import React from 'react';
 
 import { ItemCardsRow } from '../../../blocks/item-cards-row';
@@ -7,21 +8,32 @@ import styles from './quickstart.module.scss';
 
 export const Quickstart = () => {
   const { t } = useI18n();
+  const { urlLocale } = useLocale();
+
   const quickstart = {
     blockTitle: t('welcome.quickstart.title'),
     cardsData: [
       {
-        to: '/getting-started/installation/',
+        to:
+          urlLocale === 'es'
+            ? '/es/empezando/instalacion/'
+            : '/getting-started/installation/',
         title: `🚀 ${t('welcome.quickstart.installation.title')}`,
         text: t('welcome.quickstart.installation.text'),
       },
       {
-        to: '/getting-started/running-k6/',
+        to:
+          urlLocale === 'es'
+            ? '/es/empezando/ejecucion-de-k6/'
+            : '/getting-started/running-k6/',
         title: `🏎💨 ${t('welcome.quickstart.running-k6.title')}`,
         text: t('welcome.quickstart.running-k6.text'),
       },
       {
-        to: '/getting-started/results-output/',
+        to:
+          urlLocale === 'es'
+            ? '/es/empezando/instalacion/'
+            : '/getting-started/salida-de-resultados/',
         title: `⏱ ${t('welcome.quickstart.results-output.title')}`,
         text: t('welcome.quickstart.results-output.text'),
       },

--- a/src/components/pages/doc-welcome/use-cases/use-cases.view.js
+++ b/src/components/pages/doc-welcome/use-cases/use-cases.view.js
@@ -1,5 +1,6 @@
 import { Heading } from 'components/shared/heading';
 import { useI18n } from 'contexts/i18n-provider';
+import { useLocale } from 'contexts/locale-provider';
 import { Link } from 'gatsby';
 import React from 'react';
 
@@ -7,6 +8,7 @@ import styles from './use-cases.module.scss';
 
 export const UseCases = () => {
   const { t } = useI18n();
+  const { urlLocale } = useLocale();
   return (
     <section className={`container ${styles.container}`}>
       <Heading tag={'h2'} size={'lg'} className={styles.title}>
@@ -23,16 +25,34 @@ export const UseCases = () => {
             {' ('}
             <Link
               className={'link'}
-              to="/test-types/stress-testing#spike-testing-in-k6/"
+              to={
+                urlLocale === 'es'
+                  ? '/es/tipos-de-prueba/stress-testing/#spike-testing'
+                  : '/test-types/stress-testing#spike-testing-in-k6'
+              }
             >
               spike
             </Link>
             ,{' '}
-            <Link className={'link'} to="/test-types/stress-testing/">
+            <Link
+              className={'link'}
+              to={
+                urlLocale === 'es'
+                  ? '/es/tipos-de-prueba/stress-testing/'
+                  : '/test-types/stress-testing/'
+              }
+            >
               stress
             </Link>
             ,{' '}
-            <Link className={'link'} to="/test-types/soak-testing/">
+            <Link
+              className={'link'}
+              to={
+                urlLocale === 'es'
+                  ? '/es/tipos-de-prueba/soak-testing/'
+                  : '/test-types/soak-testing/'
+              }
+            >
               soak tests
             </Link>
             {') '}
@@ -47,7 +67,11 @@ export const UseCases = () => {
             {t('welcome.use-cases.performance-monitoring.description1')}{' '}
             <Link
               className={'link'}
-              to="/testing-guides/automated-performance-testing/"
+              to={
+                urlLocale === 'es'
+                  ? '/es/guias-de-prueba/automatizacion-de-pruebas-de-rendimiento/'
+                  : '/testing-guides/automated-performance-testing/'
+              }
             >
               {t('welcome.use-cases.performance-monitoring.testing-automation')}
             </Link>

--- a/src/data/markdown/translated-guides/es/01 Getting started/03 Running k6.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/03 Running k6.md
@@ -97,7 +97,7 @@ export default function () {
 </CodeGroup>
 
 El “VU Code” puede hacer peticiones HTTP, proveer métricas, y generalmente hace todo lo que se espera en una prueba de carga, no puede cargar nada desde su sistema de archivos local ni importar ningún otro módulo. Todo esto debe hacerse desde el “init Code”.
-Lea más acerca de diferentes etapas del [ciclo de vida de una prueba k6](/using-k6/test-life-cycle)
+Lea más acerca de diferentes etapas del [ciclo de vida de una prueba k6](/es/usando-k6/etapas-de-un-test/)
 
 
 ## Usando las opciones 
@@ -166,7 +166,7 @@ export default function () {
 
 </CodeGroup>
 
-Esto también se puede lograr con una configuración más avanzada utilizando [escenarios](/using-k6/scenarios) y el ejecutor `ramping-vus`.
+Esto también se puede lograr con una configuración más avanzada utilizando [escenarios](/es/usando-k6/escenarios/) y el ejecutor `ramping-vus`.
 
 ## Ejecutando las pruebas en la nube
 

--- a/src/data/markdown/translated-guides/es/01 Getting started/04 Results Output.md
+++ b/src/data/markdown/translated-guides/es/01 Getting started/04 Results Output.md
@@ -47,9 +47,9 @@ duration: 1m0s, iterations: -
 
 The test summary provides a general overview of your test result. The summary prints to `stdout` the status of:
 
-- [Métricas incorporadas](/using-k6/metrics#built-in-metrics) y [métricas personalizadas](/using-k6/metrics#custom-metrics).
-- [Checks](/using-k6/checks) and [thresholds](/using-k6/thresholds).
-- [Groups](/using-k6/tags-and-groups#groups) y [Tags](/using-k6/tags-and-groups#tags).
+- [Métricas incorporadas](/es/usando-k6/metricas/#metricas-incorporadas) y [métricas personalizadas](/es/usando-k6/metricas/#metricas-personalizadas).
+- [Checks](/es/usando-k6/checks/) and [thresholds](/es/usando-k6/thresholds/).
+- [Groups](/es/usando-k6/tags-y-groups/#groups) y [Tags](/es/usando-k6/tags-y-groups/#tags).
 
 <CodeGroup labels={[]}>
 
@@ -76,7 +76,7 @@ vus_max....................: 100    min=100 max=100
 
 **Salida de las métricas de tendencia**
 
-[Métricas de tendencia](/using-k6/metrics#metric-types) recogen las estadísticas de tendencia (min/max/avg/percentiles) de una serie de valores. En stdout se imprimen de la siguiente manera:
+[Métricas de tendencia](/es/usando-k6/metricas/#tipos-de-metricas) recogen las estadísticas de tendencia (min/max/avg/percentiles) de una serie de valores. En stdout se imprimen de la siguiente manera:
 
 <CodeGroup labels={[]}>
 
@@ -86,7 +86,7 @@ http_req_duration..........: avg=143.14ms min=112.87ms med=136.03ms max=1.18s   
 
 </CodeGroup>
 
-Puede utilizar la opción [summary-trend-stats](/using-k6/options#summary-trend-stats) para cambiar las estadísticas reportadas a las métricas de tendencia.
+Puede utilizar la opción [summary-trend-stats](/es/usando-k6/opciones/#summary-trend-stats) para cambiar las estadísticas reportadas a las métricas de tendencia.
 
 <CodeGroup labels={[]}>
 
@@ -104,15 +104,15 @@ La lista de plugins de salida son los siguientes:
 
 | Plugin                                                        | Usage                   |
 | ------------------------------------------------------------- | ----------------------- |
-| [Amazon CloudWatch](/results-visualization/amazon-cloudwatch) | `k6 run --out statsd`   |
-| [Apache Kafka](/results-visualization/apache-kafka)           | `k6 run --out kafka`    |
-| [Cloud](/results-visualization/cloud)                         | `k6 run --out cloud`    |
-| [CSV](/results-visualization/csv)                             | `k6 run --out csv`      |
-| [Datadog](/results-visualization/datadog)                     | `k6 run --out datadog`  |
-| [InfluxDB](/results-visualization/influxdb-+-grafana)         | `k6 run --out influxdb` |
-| [JSON](/results-visualization/json)                           | `k6 run --out json`     |
-| [New Relic](/results-visualization/new-relic)                 | `k6 run --out statsd`   |
-| [StatsD](/results-visualization/statsd)                       | `k6 run --out statsd`   |
+| [Amazon CloudWatch](/es/visualizacion-de-resultados/amazon-cloudwatch/) | `k6 run --out statsd`   |
+| [Apache Kafka](/es/visualizacion-de-resultados/apache-kafka/)           | `k6 run --out kafka`    |
+| [Cloud](/es/visualizacion-de-resultados/cloud/)                         | `k6 run --out cloud`    |
+| [CSV](/es/visualizacion-de-resultados/csv/)                             | `k6 run --out csv`      |
+| [Datadog](/es/visualizacion-de-resultados/datadog/)                     | `k6 run --out datadog`  |
+| [InfluxDB](/es/visualizacion-de-resultados/influxdb-+-grafana/)         | `k6 run --out influxdb` |
+| [JSON](/es/visualizacion-de-resultados/json/)                           | `k6 run --out json`     |
+| [New Relic](/es/visualizacion-de-resultados/new-relic/)                 | `k6 run --out statsd`   |
+| [StatsD](/es/visualizacion-de-resultados/statsd/)                       | `k6 run --out statsd`   |
 
 ## Salidas múltiples
 
@@ -143,4 +143,4 @@ $ k6 run --summary-export=export.json script.js
 
 </CodeGroup>
 
-> Lea más información acerca del resumen, en la [documentación del plugin de JSON](/results-visualization/json#summary-export)
+> Lea más información acerca del resumen, en la [documentación del plugin de JSON](/es/visualizacion-de-resultados/json/#exportar-los-datos-del-resumen)

--- a/src/data/markdown/translated-guides/es/02 Using k6/01 HTTP requests.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/01 HTTP requests.md
@@ -62,7 +62,7 @@ Utilice el [módulo http](/javascript-api/k6-http) para realizar todo tipo de pe
 
 ## Tags en las solicitudes HTTP 
 
-k6 aplicará automáticamente [etiquetas (tags)](/using-k6/tags-and-groups#section-tags) a sus peticiones HTTP. Estas etiquetas le permiten filtrar sus resultados durante el análisis.
+k6 aplicará automáticamente [etiquetas (tags)](/es/usando-k6/tags-y-groups/#system-tags) a sus peticiones HTTP. Estas etiquetas le permiten filtrar sus resultados durante el análisis.
 
 | Nombre   | Descripción                                |
 | ------ | ------------------------------------------ |
@@ -70,7 +70,7 @@ k6 aplicará automáticamente [etiquetas (tags)](/using-k6/tags-and-groups#secti
 | group   | Cuando una petición se ejecutan dentro de un [group](/javascript-api/k6/group-name-fn), el valor es el nombre del grupo. Por defecto está vacío.    |
 | name   | Por defecto será la URL solicitada                  |
 | method | Métodos de la solicitud (GET,POST,PUT, entre otros) |
-| scenario   | Cuando una petición se ejecutan dentro de un [scenario](/using-k6/scenarios), el valor es el nombre del grupo. Por defecto está vacío. |
+| scenario   | Cuando una petición se ejecutan dentro de un [scenario](/es/usando-k6/escenarios/), el valor es el nombre del grupo. Por defecto está vacío. |
 | status | Estatus de la respuesta                            |
 | url    | URL de la solicitud                  |
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/02 Metrics.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/02 Metrics.md
@@ -112,9 +112,9 @@ Todas las métricas (tanto las incorporadas como las personalizadas) tienen un t
 | [Rate](/javascript-api/k6-metrics/rate)       | Una métrica que registra el porcentaje de valores añadidos que son distintos de cero.                                  |
 | [Trend](/javascript-api/k6-metrics/trend)     | Una métrica que permite calcular estadísticas sobre los valores añadidos (mínimo, máximo, media y percentiles).. |
 
-All values added to a custom metric can optionally be [tagged](/using-k6/tags-and-groups) which can be useful when analysing the test results.
+All values added to a custom metric can optionally be [tagged](/es/usando-k6/tags-y-groups/) which can be useful when analysing the test results.
 
-Todos los valores añadidos a una métrica personalizada pueden ser opcionalmente [etiquetados (tags)](/using-k6/tags-and-groups), lo que puede ser útil al analizar los resultados de las pruebas.
+Todos los valores añadidos a una métrica personalizada pueden ser opcionalmente [etiquetados (tags)](/es/usando-k6/tags-y-groups/), lo que puede ser útil al analizar los resultados de las pruebas.
 
 ### Counter (métrica acumulativa)
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/03 Checks.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/03 Checks.md
@@ -6,7 +6,7 @@ excerpt: 'Checks son aserciones, pero difieren en que no detienen la ejecución,
 ## ¿Qué es un check?
 
 
-`Checks` son aserciones, pero difieren en que no detienen la ejecución, en su lugar, sólo almacenan el resultado de la comprobación, pase o no, y dejan que la ejecución del script continúe. Echa un vistazo a [Thresholds](/using-k6/thresholds) para una forma de detener la ejecución. `Checks` son excelentes para codificar aserciones relacionadas con peticiones/respuestas HTTP, asegurándose de que el código de respuesta es 2xx, por ejemplo:
+`Checks` son aserciones, pero difieren en que no detienen la ejecución, en su lugar, sólo almacenan el resultado de la comprobación, pase o no, y dejan que la ejecución del script continúe. Echa un vistazo a [Thresholds](/es/usando-k6/thresholds/) para una forma de detener la ejecución. `Checks` son excelentes para codificar aserciones relacionadas con peticiones/respuestas HTTP, asegurándose de que el código de respuesta es 2xx, por ejemplo:
 
 <CodeGroup labels={["check.js"]} lineNumbers={[true]}>
 
@@ -57,7 +57,7 @@ export default function () {
 
 Una cosa importante que hay que entender con respecto a las comprobaciones es que una comprobación fallida no fallará toda la prueba de carga.
 
-Las comprobaciones ayudan a mantener el código organizado y fácil de leer, pero cuando se ejecuta una prueba de carga en un conjunto de pruebas de CI es posible que desee comprobar las condiciones de error que fallan toda la prueba de carga. En este caso, es posible que desee combinar `Checks` con [thresholds](/using-k6/thresholds) para obtener lo que desea:
+Las comprobaciones ayudan a mantener el código organizado y fácil de leer, pero cuando se ejecuta una prueba de carga en un conjunto de pruebas de CI es posible que desee comprobar las condiciones de error que fallan toda la prueba de carga. En este caso, es posible que desee combinar `Checks` con [thresholds](/es/usando-k6/thresholds/) para obtener lo que desea:
 
 <CodeGroup labels={["check_thresholds.js"]} lineNumbers={[true]}>
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/04 Thresholds.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/04 Thresholds.md
@@ -13,9 +13,9 @@ Ejemplos de expectativas (Thresholds):
 - El tiempo de respuesta para el 95% de las solicitudes debe ser inferior a 200ms.
 - El tiempo de respuesta para el 99% de las solicitudes debe ser inferior a 400 ms.
 - El punto final específico debe responder siempre antes de 300ms.
-- Cualquier condición en una [métrica personalizada](/using-k6/metrics#custom-metrics).
+- Cualquier condición en una [métrica personalizada](/es/usando-k6/metricas/#metricas-personalizadas).
 
-Thresholds analizan las métricas de rendimiento y determinan el resultado final de la prueba (pasa/no pasa). Thresholds son esenciales para la [automatización de las pruebas de carga](/testing-guides/automated-performance-testing).
+Thresholds analizan las métricas de rendimiento y determinan el resultado final de la prueba (pasa/no pasa). Thresholds son esenciales para la [automatización de las pruebas de carga](/es/guias-de-prueba/automatizacion-de-pruebas-de-rendimiento/).
 
 
 A continuación se muestra un script de ejemplo que especifica dos thresholds, un evaluando la tasa de errores de peticiones HTTP (`http_req_failed`) y una que usa el percentil del tiempo de reqspuesta de todas las peticiones ( `http_req_duration`).

--- a/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/05 Options.md
@@ -33,7 +33,7 @@ Las opciones le permiten configurar cómo se comportará k6 durante la ejecució
 | [Minimum Iteration Duration](#minimum-iteration-duration) | Especificar la duración mínima de cada ejecución                             |
 | [No Connection Reuse](#no-connection-reuse)               | Un booleano que especifica si k6 debe desactivar las conexiones keep-alive               |
 | [No Cookies Reset](#no-cookies-reset)                     | Esto desactiva el restablecimiento del tarro de galletas después de cada iteración de la VU                      |
-| [No Summary](#no-summary)                                 | Desactiva el [resumen de fin de test](/results-visualization/end-of-test-summary)                  |
+| [No Summary](#no-summary)                                 | Desactiva el [resumen de fin de test](/es/visualizacion-de-resultados/resumen-del-final-de-la-prueba/)                  |
 | [No Thresholds](#no-thresholds)                           | Desactiva la ejecución de Thresholds                                                        |
 | [No Usage Report](#no-usage-report)                       | Un booleano que especifica si k6 debe enviar un informe de uso                          |
 | [No VU Connection Reuse](#no-vu-connection-reuse)         | Un booleano que especifica si k6 debe reutilizar las conexiones TCP                        |
@@ -46,11 +46,9 @@ Las opciones le permiten configurar cómo se comportará k6 durante la ejecució
 | [Summary export](#summary-export)                         | Guarda el informe de resumen de fin de prueba en un archivo JSON                                |
 | [Supply Env Var](#supply-env-var)                         | Añadir/sustituir la variable de entorno con VAR=valor                                    |
 | [System Tags](#system-tags)                               | Especificar qué etiquetas del sistema estarán en las métricas recogidas                          |
-| [Summary Time Unit](#summary-time-unit)                   | Unidad de tiempo para todos los valores del [resumen del fin de test](/results-visualization/end-of-test-summary)                                                      |
-| [Summary Trend Stats](#summary-trend-stats)               | Definir las estadísticas de las métricas de tendencia                                                      |
-| [Tags](#tags)                                             | Especificar `tags` que deben establecerse en todas las métricas de la prueba
-
-                        |
+| [Summary Time Unit](#summary-time-unit)                   | Unidad de tiempo para todos los valores del [resumen del fin de test](/es/visualizacion-de-resultados/resumen-del-final-de-la-prueba/)                                                      |
+| [Summary Trend Stats](#summary-trend-stats)               | Definir las estadísticas de las métricas de tendencia                 |
+| [Tags](#tags)                                             | Especificar `tags` que deben establecerse en todas las métricas de la prueba |
 | [Teardown Timeout](#teardown-timeout)                     | Especifica el tiempo de ejecución de la función `teardown()` antes de su finalización   |
 | [Thresholds](#thresholds)                                 | Configurar bajo qué condiciones una prueba tiene éxito o no                         |
 | [Throw](#throw)                                           | Un booleano que especifica si se lanzan errores en las peticiones HTTP fallidas                |
@@ -238,7 +236,7 @@ $ k6 run --block-hostnames="test.k6.io,*.example.com" script.js
 
 Soporta la ejecución de scripts con diferentes modos de compatibilidad con ECMAScript.
 
-Lea más sobre los diferentes [modos de compatibilidad con JavaScript](/using-k6/javascript-compatibility-mode).
+Lea más sobre los diferentes [modos de compatibilidad con JavaScript](/es/usando-k6/javascript-compatibility-mode/).
 
 | Env                     | CLI                    | Code / Config file | Default      |
 | ----------------------- | ---------------------- | ------------------ | ------------ |
@@ -429,7 +427,7 @@ Con el código anterior cualquier petición hecha a `test.k6.io` será redirigid
 
 Registra todas las peticiones y respuestas HTTP. Excluye el cuerpo por defecto, para incluir el cuerpo use `--http-debug=full`. 
 
-Lea más [aquí](/using-k6/http-debugging).
+Lea más [aquí](/es/usando-k6/http-debugging/).
 
 | Env             | CLI                                     | Code / Config file | Default |
 | --------------- | --------------------------------------- | ------------------ | ------- |
@@ -686,7 +684,7 @@ export let options = {
 
 ### No Summary
 
-Desactiva el [end-of-test summary](/results-visualization/end-of-test-summary) generation. Desde v0.30.0, k6 incluye [`handleSummary()`](/results-visualization/end-of-test-summary#handlesummary-callback) and `--summary-export`.
+Desactiva el [end-of-test summary](/es/visualizacion-de-resultados/resumen-del-final-de-la-prueba/) generation. Desde v0.30.0, k6 incluye [`handleSummary()`](/es/visualizacion-de-resultados/resumen-del-final-de-la-prueba/#handlesummary-callback) and `--summary-export`.
 
 | Env                | CLI               | Code / Config file | Default |
 | ------------------ | ----------------- | ------------------ | ------- |
@@ -773,7 +771,7 @@ export let options = {
 
 ### Results Output
 
-Especifique la salida de resultados. Por favor, vaya a [Salida de resultados](/getting-started/results-output) para más información sobre todos los módulos de salida disponibles y cómo configurarlos. Disponible en el comando de ejecución `k6 run`.
+Especifique la salida de resultados. Por favor, vaya a [Salida de resultados](/es/empezando/salida-de-resultados/) para más información sobre todos los módulos de salida disponibles y cómo configurarlos. Disponible en el comando de ejecución `k6 run`.
 
 
 | Env | CLI           | Code / Config file | Default |
@@ -812,7 +810,7 @@ export let options = {
 ### Scenarios
 
 Defina uno o más patrones de ejecución, con varias configuraciones de programación de VU e iteraciones, ejecutando diferentes funciones exportadas (¡además de las predeterminadas!), utilizando diferentes variables de entorno, etiquetas y más.
-Consulte el artículo [Escenarios](/using-k6/scenarios) para obtener detalles y más ejemplos.
+Consulte el artículo [Escenarios](/es/usando-k6/escenarios/) para obtener detalles y más ejemplos.
 
 
 | Env | CLI | Code / Config file | Default |
@@ -921,7 +919,7 @@ $ K6_SUMMARY_EXPORT="export.json" k6 run ~/script.js
 
 </CodeGroup>
 
-Vea un archivo de ejemplo en la [página de resultados](https://k6.io/docs/getting-started/results-output#summary-export) page.
+Vea un archivo de ejemplo en la [página de resultados](/es/empezando/salida-de-resultados/#exportando-el-resumen) page.
 
 ### Supply Env Var
 
@@ -943,7 +941,7 @@ $ k6 run -e FOO=bar ~/script.js
 
 ### System Tags
 
-Especifique qué [Tags](/using-k6/tags-and-groups#system-tags) del sistema estarán en las métricas recopiladas. Algunos recopiladores, como el de la nube, pueden requerir que se utilicen determinadas etiquetas del sistema. Puede especificar las etiquetas como un array desde los scripts JS o como una lista separada por comas a través de la CLI. 
+Especifique qué [Tags](/es/usando-k6/tags-y-groups/#system-tags) del sistema estarán en las métricas recopiladas. Algunos recopiladores, como el de la nube, pueden requerir que se utilicen determinadas etiquetas del sistema. Puede especificar las etiquetas como un array desde los scripts JS o como una lista separada por comas a través de la CLI. 
 
 | Env              | CLI             | Code / Config file | Default                                                                                                      |
 | ---------------- | --------------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
@@ -961,7 +959,7 @@ export let options = {
 
 ### Summary Time Unit
 
-Define la unidad de tiempo en [ resumen de fin de tests](/results-visualization/end-of-test-summary). Lo valores posibles son `s` (segundos), `ms` (milisegundos) y `us` (microsegundos). Si no es especificado, k6 usará la unidad más apropiada para cada valor.
+Define la unidad de tiempo en [ resumen de fin de tests](/es/visualizacion-de-resultados/resumen-del-final-de-la-prueba/). Lo valores posibles son `s` (segundos), `ms` (milisegundos) y `us` (microsegundos). Si no es especificado, k6 usará la unidad más apropiada para cada valor.
 
 | Env                    | CLI                   | Code / Config file  | Default |
 | ---------------------- | --------------------- | ------------------- | ------- |
@@ -1040,7 +1038,7 @@ export let options = {
 
 ### Thresholds
 
-Una colección de especificaciones de umbrales para configurar bajo qué condición(es) se considera que una prueba ha tenido éxito o no, cuando ha pasado o fallado, basándose en los datos métricos. Para obtener más información, consulte la documentación sobre [Thresholds](/using-k6/thresholds).
+Una colección de especificaciones de umbrales para configurar bajo qué condición(es) se considera que una prueba ha tenido éxito o no, cuando ha pasado o fallado, basándose en los datos métricos. Para obtener más información, consulte la documentación sobre [Thresholds](/es/usando-k6/thresholds/).
 
 | Env | CLI | Code / Config file | Default |
 | --- | --- | ------------------ | ------- |

--- a/src/data/markdown/translated-guides/es/02 Using k6/08 Tags and Groups.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/08 Tags and Groups.md
@@ -44,9 +44,9 @@ export default function () {
 
 Groups do the following tasks internally:
 
-- For each `group()` function, k6 emits a [group_duration metric](/using-k6/metrics) that contains the total time to execute the group function. 
+- For each `group()` function, k6 emits a [group_duration metric](/es/usando-k6/metricas/) that contains the total time to execute the group function. 
 
-- When a taggable resource: checks, requests, or custom metrics runs within a group, k6 will set the tag `group` with the current group name. Read more about it in [Tags](/using-k6/tags-and-groups#tags).
+- When a taggable resource: checks, requests, or custom metrics runs within a group, k6 will set the tag `group` with the current group name. Read more about it in [Tags](/es/usando-k6/tags-y-groups/#tags).
 
 Both options, the `group_duration` metric and `group tagging`, could help you analyze and visualize better the results of more complex tests. Check out how they work in your [k6 result output](/integrations#result-store-and-visualization).
 
@@ -73,10 +73,10 @@ group('list posts', function () {
 
 If your code looks like the example above, consider the following alternatives to write cleaner code:
 
-- For dynamic URLs, use the [URL grouping feature](/using-k6/http-requests#url-grouping).
-- To provide a meaningful name to your request, set the value of [tags.name](/using-k6/http-requests#http-request-tags).
-- To reuse common logic or organize your code better, group logic in functions or create a [local Javascript module](/using-k6/modules#local-filesystem-modules) and import it into the test script.
-- If you need to model advanced user patterns, check out [Scenarios](/using-k6/scenarios). 
+- For dynamic URLs, use the [URL grouping feature](/es/usando-k6/peticiones-http/#agrupamiento-de-las-urls).
+- To provide a meaningful name to your request, set the value of [tags.name](/es/usando-k6/peticiones-http/#tags-en-las-solicitudes-http).
+- To reuse common logic or organize your code better, group logic in functions or create a [local Javascript module](/es/usando-k6/modulos/#usando-los-modulos-locales-con-un-docker) and import it into the test script.
+- If you need to model advanced user patterns, check out [Scenarios](/es/usando-k6/escenarios/). 
 
 
 
@@ -213,7 +213,7 @@ export let options = {
 
 </CodeGroup>
 
-Lea más sobre la sintaxis de la [salida de resultados](/getting-started/results-output/json) de k6 para ver cómo las etiquetas afectan a la salida de los resultados de las pruebas.
+Lea más sobre la sintaxis de la [salida de resultados](/es/visualizacion-de-resultados/json/) de k6 para ver cómo las etiquetas afectan a la salida de los resultados de las pruebas.
 
 ## Tags y Groups en k6 Cloud
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/10 Protocols.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/10 Protocols.md
@@ -5,14 +5,14 @@ excerpt: "Por defecto, k6 viene con suporte para los siguientes protocolos: HTTP
 Por defecto, k6 viene con suporte para los siguientes protocolos:
 
 * HTTP/1.1
-* [HTTP/2](/using-k6/protocols/http-2)
-* [WebSockets](/using-k6/protocols/websockets)
-* [gRPC](/using-k6/protocols/grpc)
+* [HTTP/2](/es/usando-k6/protocolos/http-2/)
+* [WebSockets](/es/usando-k6/protocolos/websockets/)
+* [gRPC](/es/usando-k6/protocolos/grpc/)
 
 
 k6 utilizará HTTP/1.1 por defecto cuando contacte con un servidor. Si, tras la conexión, el servidor informa a k6 de que soporta HTTP/2, k6 actualizará la conexión a HTTP/2 en su lugar. Todo esto es automático - tanto el uso de HTTP/1.1 inicialmente como la potencial actualización del protocolo, y no tiene que hacer nada especial al usar k6 para activar HTTP/1.1 o HTTP/2. Sin embargo, es posible que desee verificar qué protocolo se está utilizando realmente para una transacción, lo que requiere un paso adicional.
 
-[WebSockets](/using-k6/protocols/websockets) es un poco diferente, la estructura de la prueba y el ciclo de vida de los VU es diferente.
+[WebSockets](/es/usando-k6/protocolos/websockets/) es un poco diferente, la estructura de la prueba y el ciclo de vida de los VU es diferente.
 
 k6 v0.29.0 introdujo [xk6](https://k6.io/blog/extending-k6-with-xk6) permitiendo a la comunidad construir extensiones de k6 y por tanto añadir soporte para protocolos adicionales.
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/10 Protocols/04 SSL-TLS.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/10 Protocols/04 SSL-TLS.md
@@ -19,7 +19,7 @@ Por defecto y sin ninguna configuración especial k6 se conectará y hablará co
 Vale la pena hablar con más detalle de la siguiente funcionalidad TLS soportada por k6:
 
 
-- [Certificados del cliente SSL/TLS](/using-k6/protocols/ssl-tls/ssl-tls-client-certificates)
-- [Versiones SSL/TLS y cifrados](/using-k6/protocols/ssl-tls/ssl-tls-version-and-ciphers) (restricción y comprobación de lo que se ha utilizado para una solicitud HTTP mediante la comprobación de las propiedades del objeto de respuesta)
-- [Protocolo de estado de los certificados en línea (OCSP)](/using-k6/protocols/ssl-tls/online-certificate-status-protocol-ocsp)
+- [Certificados del cliente SSL/TLS](/es/usando-k6/protocolos/ssl-tls/certificados-del-cliente-ssl-tls/)
+- [Versiones SSL/TLS y cifrados](/es/usando-k6/protocolos/ssl-tls/versiones-ssl-tls-y-cifrados/) (restricción y comprobación de lo que se ha utilizado para una solicitud HTTP mediante la comprobación de las propiedades del objeto de respuesta)
+- [Protocolo de estado de los certificados en línea (OCSP)](/es/usando-k6/protocolos/ssl-tls/protocolo-de-estado-de-los-certificados-en-linea-ocsp/)
 - [Response.timings.tls_handshaking](/javascript-api/k6-http/response)

--- a/src/data/markdown/translated-guides/es/02 Using k6/10 Protocols/04 SSL-TLS/SSL-TLS client certificates.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/10 Protocols/04 SSL-TLS/SSL-TLS client certificates.md
@@ -5,7 +5,7 @@ excerpt: 'Para utilizar los certificados de cliente se especifican las opciones 
 
 Normalmente, cuando hablamos de certificados TLS nos referimos al mecanismo por el que los clientes identifican a los servidores. Lo contrario, es decir, que los servidores identifiquen a los clientes, también es soportado tanto por TLS como por k6.
 
-Para utilizar los certificados de cliente se especifican las [opciones de configuración global](/using-k6/options) que indican a k6 cómo asignar un certificado público y una clave privada a los dominios para los que son válidos. Puedes cargar el certificado y la clave desde archivos locales o incrustarlos como cadenas en el script.
+Para utilizar los certificados de cliente se especifican las [opciones de configuración global](/es/usando-k6/opciones/) que indican a k6 cómo asignar un certificado público y una clave privada a los dominios para los que son válidos. Puedes cargar el certificado y la clave desde archivos locales o incrustarlos como cadenas en el script.
 
 ## Cargar un certificado y una clave desde archivos locales
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/10 Protocols/04 SSL-TLS/SSL-TLS version and ciphers.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/10 Protocols/04 SSL-TLS/SSL-TLS version and ciphers.md
@@ -7,7 +7,7 @@ Para soportar las pruebas de configuraciones específicas de los clientes, k6 le
 
 ## Limiting SSL/TLS version
 
-Limitar las versiones de SSL/TLS que k6 podrá utilizar durante una prueba es una [opción de configuración global](/using-k6/options). Puede elegir limitar a una versión específica:
+Limitar las versiones de SSL/TLS que k6 podrá utilizar durante una prueba es una [opción de configuración global](/es/usando-k6/opciones/). Puede elegir limitar a una versión específica:
 
 <CodeGroup labels={["Limiting to a specific SSL/TLS version"]} lineNumbers={[true]}>
 
@@ -57,7 +57,7 @@ A continuación se muestra la lista de versiones de SSL/TLS disponibles entre la
 
 ## Limitación de los conjuntos de cifrado
 
-La limitación de los conjuntos de cifrado que k6 puede utilizar durante una prueba es una [opción de configuración global](/using-k6/options). Usted elige una lista de cifrados permitidos:
+La limitación de los conjuntos de cifrado que k6 puede utilizar durante una prueba es una [opción de configuración global](/es/usando-k6/opciones/). Usted elige una lista de cifrados permitidos:
 
 <CodeGroup labels={["Limiting cipher suites"]} lineNumbers={[true]}>
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/11 Environment variables.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/11 Environment variables.md
@@ -77,5 +77,5 @@ k6 también intentará leer algunas variables de entorno específicas que el usu
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `K6_CLOUD_HOST`      | Una URL a la que conectarse, cuando se especifica la opción de salida de resultados `--out=cloud`.                                          |
 | `K6_CLOUD_TOKEN`     | Un token de autenticación para utilizar en las llamadas a la API del servicio en la nube, cuando se especifica la opción de salida de resultados `--cloud`. |
-| `K6_NO_USAGE_REPORT` | Defina esto para desactivar los [informes de uso.](/misc/usage-collection).                                                        |
+| `K6_NO_USAGE_REPORT` | Defina esto para desactivar los [informes de uso.](/es/misc/recopilacion-de-datos-de-uso/).                                                        |
 | `K6_OUT`             | Especifica la salida de resultados, igual que la opción de línea de comandos `--out`.                                                             |

--- a/src/data/markdown/translated-guides/es/02 Using k6/12 Execution context variables.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/12 Execution context variables.md
@@ -3,7 +3,7 @@ title: 'Variables de contexto'
 excerpt: 'VU y ITER son variables globales con información del contexto de ejecución que k6 pone a disposición del script de prueba.'
 ---
 
-[El tutorial "Ejecución de k6"](/getting-started/running-k6)  describe cómo k6 ejecuta un script de prueba para un número especificado de Usuarios Virtuales (VUs) y una duración de tiempo o un número fijo de iteraciones para cada VU.
+[El tutorial "Ejecución de k6"](/es/empezando/ejecucion-de-k6/)  describe cómo k6 ejecuta un script de prueba para un número especificado de Usuarios Virtuales (VUs) y una duración de tiempo o un número fijo de iteraciones para cada VU.
 
 Cuando se especifica la opción de duración, k6 ejecutará continuamente el script de prueba para cada VU hasta que la cantidad de tiempo de duración haya transcurrido.
 
@@ -39,7 +39,7 @@ Número actual de la VU. El valor se asigna de forma incremental para cada nueva
 
 > ### ⚠️ Información de contexto adicional disponible en k6 Cloud
 >
-> Si está ejecutando una prueba en k6 Cloud tendrá variables de entorno adicionales que le indicarán en qué servidor, zona de carga y distribución de la prueba se está ejecutando actualmente. Puede leer más sobre ellas [aquí](/using-k6/environment-variables).
+> Si está ejecutando una prueba en k6 Cloud tendrá variables de entorno adicionales que le indicarán en qué servidor, zona de carga y distribución de la prueba se está ejecutando actualmente. Puede leer más sobre ellas [aquí](/es/usando-k6/variables-de-entorno/).
 
 ## Coordinador de Pruebas k6
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios.md
@@ -45,7 +45,7 @@ export let options = {
 
 ## Executors
 
-[Executors](/using-k6/scenarios/executors) son los workhorses del motor de ejecución de k6. Cada uno programa los VUs y las iteraciones de forma diferente, y usted podrá elegir uno dependiendo del tipo de tráfico que quiera modelar para probar sus servicios.
+[Executors](/es/usando-k6/escenarios/executors/) son los workhorses del motor de ejecución de k6. Cada uno programa los VUs y las iteraciones de forma diferente, y usted podrá elegir uno dependiendo del tipo de tráfico que quiera modelar para probar sus servicios.
  
 Los posibles valores para los `executor` son los siguientes: 
 
@@ -53,13 +53,13 @@ Los posibles valores para los `executor` son los siguientes:
 
 | Nombre           | Valor | Descripción                                                            |
 | ---------------- | ----------------------- | ---------------------------------------------------- |
-| [Shared iterations](/using-k6/scenarios/executors/shared-iterations)         | `shared-iterations`     | Una cantidad fija de iteraciones que son "compartidas" entre un número de VUs.                                                                            |
-| [Per VU iterations](/using-k6/scenarios/executors/per-vu-iterations)         | `per-vu-iterations`     | Cada VU ejecuta un número exacto de iteraciones.                                                                                                    |
-| [Constant VUs](/using-k6/scenarios/executors/constant-vus)                   | `constant-vus`          | Un número fijo de VUs que ejecuta una cantidad de iteraciones determinada, durante un tiempo determinado.                                                  |
-| [Ramping VUs](/using-k6/scenarios/executors/ramping-vus)                     | `ramping-vus`           | Un número variable de VUs que ejecuta una cantidad de iteraciones determinada, durante un tiempo determinado.                                               |
-| [Constant Arrival Rate](/using-k6/scenarios/executors/constant-arrival-rate) | `constant-arrival-rate` | Se ejecuta un número fijo de iteraciones en un periodo de tiempo determinado.                                                                      |
-| [Ramping Arrival Rate](/using-k6/scenarios/executors/ramping-arrival-rate)   | `ramping-arrival-rate`  | Se ejecuta un número variable de iteraciones, ejecutadas en un periodo de tiempo determinado.                                          |
-| [Externally Controlled](/using-k6/scenarios/executors/externally-controlled) | `externally-controlled` | Controla y escala la ejecución en runtime a través  [k6's REST API](/misc/k6-rest-api) o [CLI](https://k6.io/blog/how-to-control-a-live-k6-test). |
+| [Shared iterations](/es/usando-k6/escenarios/executors/shared-iterations/)         | `shared-iterations`     | Una cantidad fija de iteraciones que son "compartidas" entre un número de VUs.                                                                            |
+| [Per VU iterations](/es/usando-k6/escenarios/executors/per-vu-iterations/)         | `per-vu-iterations`     | Cada VU ejecuta un número exacto de iteraciones.                                                                                                    |
+| [Constant VUs](/es/usando-k6/escenarios/executors/constant-vus/)                   | `constant-vus`          | Un número fijo de VUs que ejecuta una cantidad de iteraciones determinada, durante un tiempo determinado.                                                  |
+| [Ramping VUs](/es/usando-k6/escenarios/executors/ramping-vus/)                     | `ramping-vus`           | Un número variable de VUs que ejecuta una cantidad de iteraciones determinada, durante un tiempo determinado.                                               |
+| [Constant Arrival Rate](/es/usando-k6/escenarios/executors/constant-arrival-rate/) | `constant-arrival-rate` | Se ejecuta un número fijo de iteraciones en un periodo de tiempo determinado.                                                                      |
+| [Ramping Arrival Rate](/es/usando-k6/escenarios/executors/ramping-arrival-rate/)   | `ramping-arrival-rate`  | Se ejecuta un número variable de iteraciones, ejecutadas en un periodo de tiempo determinado.                                          |
+| [Externally Controlled](/es/usando-k6/escenarios/executors/externally-controlled/) | `externally-controlled` | Controla y escala la ejecución en runtime a través  [k6's REST API](/misc/k6-rest-api) o [CLI](https://k6.io/blog/how-to-control-a-live-k6-test). |
 
 ## Opciones comunes
 
@@ -70,4 +70,4 @@ Los posibles valores para los `executor` son los siguientes:
 | `gracefulStop` | string | Tiempo para esperar a que las iteraciones terminen de ejecutarse antes de detenerlas forzosamente. Véase la sección [gracefulStop](#graceful-stop-and-ramp-down). | `"30s"`     |
 | `exec`         | string | Nombre de la función JS exportada a ejecutar.                                                                                                       | `"default"` |
 | `env`          | object | Variables de entorno específicas para este escenario.                                                                                               | `{}`        |
-| `tags`         | object | [Tags](/using-k6/tags-and-groups) específicas para este escenario. | `{}`        |
+| `tags`         | object | [Tags](/es/usando-k6/tags-y-groups/) específicas para este escenario. | `{}`        |

--- a/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/01 Executors.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/01 Executors.md
@@ -3,16 +3,16 @@ title: 'Executors'
 excerpt: 'Executors son los caballos de batalla del motor de ejecución k6. Cada uno programa los VUs y las iteraciones de forma diferente, y usted elegirá uno dependiendo del tipo de tráfico que quiera modelar para probar sus servicios.'
 ---
 
-[Executors](/using-k6/scenarios/executors) son los caballos de batalla del motor de ejecución k6. Cada uno programa los VUs y las iteraciones de forma diferente, y usted elegirá uno dependiendo del tipo de tráfico que quiera modelar para probar sus servicios.
+[Executors](/es/usando-k6/escenarios/executors) son los caballos de batalla del motor de ejecución k6. Cada uno programa los VUs y las iteraciones de forma diferente, y usted elegirá uno dependiendo del tipo de tráfico que quiera modelar para probar sus servicios.
 
 Los valores posibles para el `executor` son el nombre del ejecutor separado por guiones.
 
 | Nombre           | Valor | Descripción                                                            |
 | ---------------- | ----------------------- | ---------------------------------------------------- |
-| [Shared iterations](/using-k6/scenarios/executors/shared-iterations)         | `shared-iterations`     | Una cantidad fija de iteraciones que son "compartidas" entre un número de VUs.                                                                            |
-| [Per VU iterations](/using-k6/scenarios/executors/per-vu-iterations)         | `per-vu-iterations`     | Cada VU ejecuta un número exacto de iteraciones.                                                                                                    |
-| [Constant VUs](/using-k6/scenarios/executors/constant-vus)                   | `constant-vus`          | Un número fijo de VUs que ejecuta una cantidad de iteraciones determinada, durante un tiempo determinado.                                                  |
-| [Ramping VUs](/using-k6/scenarios/executors/ramping-vus)                     | `ramping-vus`           | Un número variable de VUs que ejecuta una cantidad de iteraciones determinada, durante un tiempo determinado.                                               |
-| [Constant Arrival Rate](/using-k6/scenarios/executors/constant-arrival-rate) | `constant-arrival-rate` | Se ejecuta un número fijo de iteraciones en un periodo de tiempo determinado.                                                                      |
-| [Ramping Arrival Rate](/using-k6/scenarios/executors/ramping-arrival-rate)   | `ramping-arrival-rate`  | Se ejecuta un número variable de iteraciones, ejecutadas en un periodo de tiempo determinado.                                          |
-| [Externally Controlled](/using-k6/scenarios/executors/externally-controlled) | `externally-controlled` | Controla y escala la ejecución en runtime a través  [k6's REST API](/misc/k6-rest-api) o [CLI](https://k6.io/blog/how-to-control-a-live-k6-test). |
+| [Shared iterations](/es/usando-k6/escenarios/executors/shared-iterations/)         | `shared-iterations`     | Una cantidad fija de iteraciones que son "compartidas" entre un número de VUs.                                                                            |
+| [Per VU iterations](/es/usando-k6/escenarios/executors/per-vu-iterations/)         | `per-vu-iterations`     | Cada VU ejecuta un número exacto de iteraciones.                                                                                                    |
+| [Constant VUs](/es/usando-k6/escenarios/executors/constant-vus/)                   | `constant-vus`          | Un número fijo de VUs que ejecuta una cantidad de iteraciones determinada, durante un tiempo determinado.                                                  |
+| [Ramping VUs](/es/usando-k6/escenarios/executors/ramping-vus)                     | `ramping-vus`           | Un número variable de VUs que ejecuta una cantidad de iteraciones determinada, durante un tiempo determinado.                                               |
+| [Constant Arrival Rate](/es/usando-k6/escenarios/executors/constant-arrival-rate/) | `constant-arrival-rate` | Se ejecuta un número fijo de iteraciones en un periodo de tiempo determinado.                                                                      |
+| [Ramping Arrival Rate](/es/usando-k6/escenarios/executors/ramping-arrival-rate)   | `ramping-arrival-rate`  | Se ejecuta un número variable de iteraciones, ejecutadas en un periodo de tiempo determinado.                                          |
+| [Externally Controlled](/es/usando-k6/escenarios/executors/externally-controlled/) | `externally-controlled` | Controla y escala la ejecución en runtime a través  [k6's REST API](/misc/k6-rest-api) o [CLI](https://k6.io/blog/how-to-control-a-live-k6-test). |

--- a/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/01 Executors/05 constant-arrival-rate.md
@@ -7,7 +7,7 @@ excerpt: 'Se ejecuta un número fijo de iteraciones en un periodo de tiempo dete
 
 Se ejecuta un número fijo de iteraciones en un periodo de tiempo determinado. Dado que el tiempo de ejecución de la iteración puede variar debido a la lógica de la prueba o a que el sistema bajo prueba responda más lentamente, este ejecutor intentará compensar ejecutando un número variable de VUs incluyendo la posibilidad de inicializar más en medio de la prueba para cumplir con la tasa de iteración configurada. Este enfoque es útil para una representación más precisa de RPS, por ejemplo.
 
-Consulte [arrival rate](/using-k6/scenarios/arrival-rate) para más detalles.
+Consulte [arrival rate](/es/usando-k6/escenarios/arrival-rate/) para más detalles.
 
 ## Opciones
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/01 Executors/06 ramping-arrival-rate.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/01 Executors/06 ramping-arrival-rate.md
@@ -7,7 +7,7 @@ excerpt: 'Se ejecuta un número variable de iteraciones en un periodo de tiempo 
 
 Se ejecuta un número variable de iteraciones en un periodo de tiempo determinado. Este es similar al ejecutor de VUs en rampa, pero para iteraciones en su lugar, y k6 intentará cambiar dinámicamente el número de VUs para alcanzar la tasa de iteración configurada.
 
-See the [arrival rate](/using-k6/scenarios/arrival-rate) section for details.
+See the [arrival rate](/es/usando-k6/escenarios/arrival-rate/) section for details.
 
 ## Opciones
 

--- a/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/02 Advanced Examples.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/02 Advanced Examples.md
@@ -49,7 +49,7 @@ export function news() {
 
 ## Diferentes variables de entorno y etiquetas por escenario
 
-En el ejemplo anterior establecimos etiquetas en métricas individuales de solicitudes HTTP, pero esto también puede hacerse por escenario, lo que las aplicaría también a otros objetos [etiquetables (tags)](https://k6.io/docs/using-k6/tags-and-groups#tags).
+En el ejemplo anterior establecimos etiquetas en métricas individuales de solicitudes HTTP, pero esto también puede hacerse por escenario, lo que las aplicaría también a otros objetos [etiquetables (tags)](/es/usando-k6/tags-y-groups/#tags).
 
 
 <CodeGroup labels={[ "multiple-scenarios-env-tags.js" ]} lineNumbers={[true]}>

--- a/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/03 Graceful stop.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/03 Graceful stop.md
@@ -47,4 +47,4 @@ Nótese que aunque la duración total de la prueba es de 10s, el tiempo real de 
 
 ## Información adicional
 
-Existe una opción similar para el [ramping-vus](/using-k6/scenarios/executors/ramping-vus) executor: `gracefulRampDown`. Esto especifica el tiempo que k6 debe esperar para que cualquier iteración en progreso termine antes de que las VUs sean devueltas al pool global durante un período de rampa de descenso definido en `stages`.
+Existe una opción similar para el [ramping-vus](/es/usando-k6/escenarios/executors/ramping-vus/) executor: `gracefulRampDown`. Esto especifica el tiempo que k6 debe esperar para que cualquier iteración en progreso termine antes de que las VUs sean devueltas al pool global durante un período de rampa de descenso definido en `stages`.

--- a/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/04 Arrival Rate.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/14 Scenarios/04 Arrival Rate.md
@@ -66,7 +66,7 @@ Para solucionar este problema utilizamos un modelo abierto, desvinculando el ini
 ![Arrival rate closed/open models](../images/Scenarios/arrival-rate-open-closed-model.png)
 
 
-En k6, hemos implementado este modelo abierto con nuestros dos executors de "tasa de llegada (Arrival Rate)" [constant-arrival-rate](/using-k6/scenarios/executors/constant-arrival-rate) and [ramping-arrival-rate](/using-k6/scenarios/executors/ramping-arrival-rate):
+En k6, hemos implementado este modelo abierto con nuestros dos executors de "tasa de llegada (Arrival Rate)" [constant-arrival-rate](/es/usando-k6/escenarios/executors/constant-arrival-rate/) and [ramping-arrival-rate](/es/usando-k6/escenarios/executors/ramping-arrival-rate/):
 
 <CodeGroup labels={[ "open-model.js" ]} lineNumbers={[true]}>
 

--- a/src/data/markdown/translated-guides/es/03 Test authoring/01 test builder.md
+++ b/src/data/markdown/translated-guides/es/03 Test authoring/01 test builder.md
@@ -5,7 +5,7 @@ excerpt: 'El constructor de pruebas (Test Builder) permite utilizar una interfaz
 
 El constructor de pruebas (Test Builder) permite utilizar una interfaz gráfica para crear una prueba.
 
-Basándose en los datos de entrada, el constructor de pruebas le generará automáticamente el script. Una vez hecho esto, puede copiar el script y [ejecutar la prueba desde la CLI (command line interface) ](/getting-started/running-k6).
+Basándose en los datos de entrada, el constructor de pruebas le generará automáticamente el script. Una vez hecho esto, puede copiar el script y [ejecutar la prueba desde la CLI (command line interface) ](/es/empezando/ejecucion-de-k6/).
 
 > **Nota**: Es necesario tener una cuenta de k6 Cloud para utilizar el constructor de pruebas. Sin embargo, su uso es gratuito y por lo tanto no necesita una suscripción activa para utilizar esta función.
 
@@ -38,7 +38,7 @@ Aunque creemos firmemente que las herramientas basadas en scripts o códigos le 
 Continuamente mejoramos y añadimos nuevas características al generador de pruebas. Algunas de las características más destacadas son las siguientes:
 
 **Configuración de pruebas**
-- Configurar el ramping(aka [stages](/using-k6/options#stages)) usando VUs y la duración.
+- Configurar el ramping(aka [stages](/es/usando-k6/opciones/#stages)) usando VUs y la duración.
 - Configurar las [zonas de carga](/cloud/creating-and-running-a-test/cloud-tests-from-the-cli#list-of-supported-load-zones) para ejecutarlo desde k6 Cloud.
 
 
@@ -54,13 +54,13 @@ Continuamente mejoramos y añadimos nuevas características al generador de prue
 
 
 **API de k6**
-- Define [thresholds](/using-k6/thresholds).
+- Define [thresholds](/es/usando-k6/thresholds/).
 - Añada [checks](/javascript-api/k6/check-val-sets-tags).
 - Añada [sleep](/javascript-api/k6/sleep-t).
 - Añada [group](/javascript-api/k6/group-name-fn).
 
 **Algunas otras características**
-- Rellenar el constructor de pruebas con las peticiones grabadas utilizando el [grabador del navegador](/test-authoring/recording-a-session/browser-recorder).
+- Rellenar el constructor de pruebas con las peticiones grabadas utilizando el [grabador del navegador](/es/creacion-de-pruebas/grabar-una-sesion/grabador-de-navegador/).
 - Rellenar el constructor de pruebas con las peticiones incluidas en un [archivo HAR](<https://en.wikipedia.org/wiki/HAR_(file_format)>).
 - Capturar una variable cuando se trata de datos dinámicos, como los tokens de autenticación.
 - Mostrar ejemplos para un mejor entendimiento.

--- a/src/data/markdown/translated-guides/es/03 Test authoring/02 Recording a session.md
+++ b/src/data/markdown/translated-guides/es/03 Test authoring/02 Recording a session.md
@@ -15,7 +15,7 @@ Supongamos que hay que crear una prueba de rendimiento que simula el comportamie
 
 k6 proporciona dos mecanismos para generar un script a partir de una sesión de usuario grabada:
 
-- [Browser recorder](/test-authoring/recording-a-session/browser-recorder) genera un script de k6 a partir de una sesión del navegador. Disponible en
+- [Browser recorder](/es/creacion-de-pruebas/grabar-una-sesion/grabador-de-navegador/) genera un script de k6 a partir de una sesión del navegador. Disponible en
  [Chrome](https://chrome.google.com/webstore/detail/k6-browser-recorder/phjdhndljphphehjpgbmpocddnnmdbda?hl=en) y [Firefox](https://addons.mozilla.org/en-US/firefox/addon/k6-browser-recorder/).
-- [HAR converter](/test-authoring/recording-a-session/har-converter) genera un script de k6 a partir de las peticiones incluidas en un archivo de tipo HAR.
+- [HAR converter](/es/creacion-de-pruebas/grabar-una-sesion/har-converter/) genera un script de k6 a partir de las peticiones incluidas en un archivo de tipo HAR.
  

--- a/src/data/markdown/translated-guides/es/03 Test authoring/02 Recording a session/01 Browser recorder.md
+++ b/src/data/markdown/translated-guides/es/03 Test authoring/02 Recording a session/01 Browser recorder.md
@@ -65,7 +65,7 @@ Si quiere incluir algunas de las solicitudes en la lista de terceros, simplement
 5 - **Edite su script** según sea necesario
 
 Dependiendo del tipo de prueba, es posible que tenga que cambiar diferentes aspectos del script. Los cambios más habituales son
-- Cambiar las [opciones de carga](/using-k6/options). El valor por defecto es una prueba con ramp-up de 12 minutos.
+- Cambiar las [opciones de carga](/es/usando-k6/opciones/). El valor por defecto es una prueba con ramp-up de 12 minutos.
 - Manejar la [correlación y los datos dinámicos](/examples/correlation-and-dynamic-data).
 
 6 - **Ejecute la prueba** localmente o en k6 Cloud
@@ -74,7 +74,7 @@ Si desea ejecutar una prueba en la nube desde la interfaz de usuario de k6 Cloud
 
 Si desea utilizar la CLI (command-line interface) de k6 para ejecutar una prueba local o k6 Cloud, copie el script generado en su editor de texto local y ejecute el comando `k6 run` o `k6 cloud` para iniciar la prueba.
 
-Para obtener más información sobre la ejecución de k6, consulte la [guía Ejecución de k6](/getting-started/running-k6).
+Para obtener más información sobre la ejecución de k6, consulte la [guía Ejecución de k6](/es/empezando/ejecucion-de-k6/).
 
 ## Solución de problemas
 

--- a/src/data/markdown/translated-guides/es/03 Test authoring/02 Recording a session/02 Har converter.md
+++ b/src/data/markdown/translated-guides/es/03 Test authoring/02 Recording a session/02 Har converter.md
@@ -3,7 +3,7 @@ title: 'HAR converter'
 excerpt: 'El convertidor HAR es una alternativa al grabador del navegador (Browser recorder). Genera un script de k6 basado en las peticiones HTTP incluidas en un archivo HAR.'
 ---
 
-El convertidor HAR es una alternativa al [grabador del navegador (Browser recorder)](/test-authoring/recording-a-session/browser-recorder). Genera un script de k6 basado en las peticiones HTTP incluidas en un archivo HAR.
+El convertidor HAR es una alternativa al [grabador del navegador (Browser recorder)](/es/creacion-de-pruebas/grabar-una-sesion/grabador-de-navegador/). Genera un script de k6 basado en las peticiones HTTP incluidas en un archivo HAR.
 
 > HAR es un formato de archivo utilizado por los principales navegadores y otras herramientas para exportar las peticiones HTTP registradas.
 
@@ -113,7 +113,7 @@ export let options = {
 };
 ```
 
-Para obtener más información sobre cómo configurar las opciones de carg, puede leer la guía [Añadir más VUs](/getting-started/running-k6#adding-more-vus) y [Options](/using-k6/options).
+Para obtener más información sobre cómo configurar las opciones de carg, puede leer la guía [Añadir más VUs](/es/empezando/ejecucion-de-k6/#agregando-mas-usuarios-virtuales-vus) y [Options](/es/usando-k6/opciones/).
 
 ### Eliminar el contenido de terceros
 
@@ -155,7 +155,7 @@ Para ejecutar su prueba de carga correctamente, es posible que tenga que reempla
 
 ## 4. Ejecute la prueba
 
-Ahora, puede ejecutar su prueba de carga con k6. Si aún no ha instalado k6, por favor, siga las [instrucciones de instalación de k6](/getting-started/installation).
+Ahora, puede ejecutar su prueba de carga con k6. Si aún no ha instalado k6, por favor, siga las [instrucciones de instalación de k6](/es/empezando/instalacion/).
 Ejecute el comando `k6 run` para ejecutar su script de k6:
 
 
@@ -163,8 +163,8 @@ Ejecute el comando `k6 run` para ejecutar su script de k6:
 $ k6 run loadtest.js
 ```
 
-Para saber más sobre la ejecución de k6, consulte la [guía de ejecución de k6](/getting-started/running-k6).
+Para saber más sobre la ejecución de k6, consulte la [guía de ejecución de k6](/es/empezando/ejecucion-de-k6/).
 
 ## Vea también
 
-- [Grabador del navegador (Browser recorder)](/test-authoring/recording-a-session/browser-recorder): Extensiones de Chrome y Firefox para generar un script de k6 a partir de una sesión del navegador.
+- [Grabador del navegador (Browser recorder)](/es/creacion-de-pruebas/grabar-una-sesion/grabador-de-navegador/): Extensiones de Chrome y Firefox para generar un script de k6 a partir de una sesión del navegador.

--- a/src/data/markdown/translated-guides/es/04 Results visualization/00 End-of-test Summary.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/00 End-of-test Summary.md
@@ -3,7 +3,7 @@ title: 'Resumen del final de la prueba'
 excerpt: 'Por defecto, al final de cada prueba local, k6 imprime un informe de resumen en stdout que contiene una visión general de los resultados de la prueba.'
 ---
 
-Por defecto, al final de cada prueba local, k6 imprime un informe de resumen en stdout que contiene una visión general de los resultados de la prueba. Incluye los valores agregados de todas las métricas y submétricas [incorporadas](/using-k6/metrics#built-in-metrics) y [propias](/using-k6/metrics#custom-metrics), [thresholds](/using-k6/thresholds), [groups](/using-k6/tags-and-groups#groups), y [checks](/using-k6/checks). Puede tener un aspecto similar al siguiente:
+Por defecto, al final de cada prueba local, k6 imprime un informe de resumen en stdout que contiene una visión general de los resultados de la prueba. Incluye los valores agregados de todas las métricas y submétricas [incorporadas](/es/usando-k6/metricas/#metricas-incorporadas) y [propias](/es/usando-k6/metricas/#metricas-personalizadas), [thresholds](/es/usando-k6/thresholds/), [groups](/es/usando-k6/tags-y-groups/#groups), y [checks](/es/usando-k6/checks/). Puede tener un aspecto similar al siguiente:
 
 
 <CodeGroup labels={[]}>
@@ -42,14 +42,14 @@ Por defecto, al final de cada prueba local, k6 imprime un informe de resumen en 
 
 Algunas opciones pueden afectar al comportamiento de este informe:
 
-- La opción [`--summary-trend-stats` option](/using-k6/options#summary-trend-stats) le permite definir qué estadísticas de las métricas de tendencia se calcularán y mostrarán.
-- La opción [`--summary-time-unit` option](/using-k6/options#summary-time-unit) obliga a k6 a utilizar una unidad de tiempo fija para todos los valores de tiempo en el resumen.
-- La opción [`no-summary`](/using-k6/options#no-summary) desactiva completamente la generación de informes. Disponible desde la versión de k6  v0.30.0 que incluye `--summary-export` y `handleSummary()`.
+- La opción [`--summary-trend-stats` option](/es/usando-k6/opciones/#summary-trend-stats) le permite definir qué estadísticas de las métricas de tendencia se calcularán y mostrarán.
+- La opción [`--summary-time-unit` option](/es/usando-k6/opciones/#summary-time-unit) obliga a k6 a utilizar una unidad de tiempo fija para todos los valores de tiempo en el resumen.
+- La opción [`no-summary`](/es/usando-k6/opciones/#no-summary) desactiva completamente la generación de informes. Disponible desde la versión de k6  v0.30.0 que incluye `--summary-export` y `handleSummary()`.
 
 
 ## Exportación de un resumen a un archivo JSON
 
-Desde la versión 0.26.0 k6 se tiene [`--summary-export=path/to/file.json` option](/using-k6/options#summary-export) para las ejecuciones de pruebas locales. Esta opción exporta algunos de los datos del informe de resumen a un formato de archivo JSON.
+Desde la versión 0.26.0 k6 se tiene [`--summary-export=path/to/file.json` option](/es/usando-k6/opciones/#summary-export) para las ejecuciones de pruebas locales. Esta opción exporta algunos de los datos del informe de resumen a un formato de archivo JSON.
 
 Desafortunadamente, el formato exportado es algo limitado y tiene algunas peculiaridades confusas. Por ejemplo, los grupos y las comprobaciones no están ordenados. Los valores de los umbrales también son algo poco intuitivos: indican si se ha superado el umbral. Así, true es el valor de umbral "malo", es decir, cuando el umbral ha fallado, y false es el valor "bueno"...
 

--- a/src/data/markdown/translated-guides/es/04 Results visualization/01 Amazon CloudWatch.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/01 Amazon CloudWatch.md
@@ -61,7 +61,7 @@ Suponemos que ya tiene una máquina que soporta tanto la ejecución de k6 como d
 
 ## Ejecutar la prueba con k6
 
-Una vez que el agente esté funcionando correctamente, [instale](/getting-started/installation) k6 y [ejecute](/getting-started/running-k6)  la prueba, para que las métricas sean enviadas al agente mediante el siguiente comando:
+Una vez que el agente esté funcionando correctamente, [instale](/es/empezando/instalacion/) k6 y [ejecute](/es/empezando/ejecucion-de-k6/)  la prueba, para que las métricas sean enviadas al agente mediante el siguiente comando:
 
 ```bash
 $ k6 run --out statsd script.js

--- a/src/data/markdown/translated-guides/es/04 Results visualization/03 CSV.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/03 CSV.md
@@ -55,5 +55,5 @@ Cada entrada en el informe representa una métrica `metric_name` junto con su va
 
 ## Véase también
 
-- [Métricas](/using-k6/metrics)
+- [Métricas](/es/usando-k6/metricas/)
 - [Error codes](/javascript-api/error-codes)

--- a/src/data/markdown/translated-guides/es/04 Results visualization/04 DataDog.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/04 DataDog.md
@@ -85,7 +85,7 @@ Puede visualizar las métricas de k6 en tiempo real con el [explorador de métri
 
 <blockquote>
 
-Para saber más sobre todos los tipos de métricas de k6, lea la guía de [métricas de k6](/using-k6/metrics).
+Para saber más sobre todos los tipos de métricas de k6, lea la guía de [métricas de k6](/es/usando-k6/metricas/).
 
 </blockquote>
 

--- a/src/data/markdown/translated-guides/es/04 Results visualization/05 InfluxDB - Grafana.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/05 InfluxDB - Grafana.md
@@ -7,7 +7,7 @@ Puedes utilizar [Grafana](https://grafana.com/grafana/) para visualizar las mét
 
 El primer paso es subir las métricas de los resultados de las pruebas a un backend de almacenamiento. Y a continuación, configurar Grafana para obtener los datos de su backend para visualizar los resultados de las pruebas.
 
-Este tutorial muestra cómo subir las métricas de los resultados de las pruebas a una instancia de [InfluxDB](https://github.com/influxdata/influxdb) y configurar Grafana para consultar las [métricas de k6](/using-k6/metrics) desde InfluxDB.
+Este tutorial muestra cómo subir las métricas de los resultados de las pruebas a una instancia de [InfluxDB](https://github.com/influxdata/influxdb) y configurar Grafana para consultar las [métricas de k6](/es/usando-k6/metricas/) desde InfluxDB.
 
 ![Grafana Visualization](./images/InfluxDB-Grafana/grafana-visualization.png)
 

--- a/src/data/markdown/translated-guides/es/04 Results visualization/06 JSON.md
+++ b/src/data/markdown/translated-guides/es/04 Results visualization/06 JSON.md
@@ -247,4 +247,4 @@ El formato del fichero sería de la siguiente forma:
 
 ## Véase también
 
-- [Métricas](/using-k6/metrics)
+- [Métricas](/es/usando-k6/metricas/)

--- a/src/data/markdown/translated-guides/es/05 Test Types/00 Introduction.md
+++ b/src/data/markdown/translated-guides/es/05 Test Types/00 Introduction.md
@@ -9,38 +9,16 @@ Es posible realizar muchos tipos de pruebas con k6, cada uno de los cuales son u
 
 Cada tipo de prueba está diseñado para proporcionarle diferentes conocimientos sobre su sistema.
 
-[Smoke Test (Prueba de Humo)](/test-types/smoke-testing): verifica que su sistema puede manejar una carga mínima, sin ningún problema.
+[Smoke Test (Prueba de Humo)](/es/tipos-de-prueba/smoke-testing/): verifica que su sistema puede manejar una carga mínima, sin ningún problema.
 
-[Load Test (Prueba de Carga)](/test-types/load-testing): se ocupa principalmente de evaluar el rendimiento de su sistema en términos de usuarios concurrentes o solicitudes por segundo.
+[Load Test (Prueba de Carga)](/es/tipos-de-prueba/load-testing/): se ocupa principalmente de evaluar el rendimiento de su sistema en términos de usuarios concurrentes o solicitudes por segundo.
 
-[Stress Test (Prueba de Estrés)](/test-types/stress-testing) y [Spike testing (Prueba de Pico)](/test-types/stress-testing#spike-testing-in-k6): se ocupan de evaluar los límites de su sistema y la estabilidad en condiciones extremas.
+[Stress Test (Prueba de Estrés)](/es/tipos-de-prueba/stress-testing/) y [Spike testing (Prueba de Pico)](/es/tipos-de-prueba/stress-testing/#spike-testing-en-k6): se ocupan de evaluar los límites de su sistema y la estabilidad en condiciones extremas.
 
-[Soak Test (Prueba de Resistencia)](/test-types/soak-testing): le informa sobre la fiabilidad y el rendimiento de su sistema durante un periodo de tiempo prolongado.
+[Soak Test (Prueba de Resistencia)](/es/tipos-de-prueba/soak-testing/): le informa sobre la fiabilidad y el rendimiento de su sistema durante un periodo de tiempo prolongado.
 
 Lo importante es entender que cada prueba se puede realizar con el mismo script de prueba. Puedes escribir un script y realizar todas las pruebas anteriores con él. Lo único que cambia es la configuración de la prueba, la lógica permanece igual.
 
 Los diferentes tipos de pruebas le enseñarán diferentes cosas sobre su sistema y le darán la información necesaria para entender y optimizar el rendimiento.
 
-Comience con [Smoke test (Prueba de Humo)](/test-types/smoke-testing) y vea lo fácil que es hacer su primera prueba de carga.
-
-
-<!--
- Note that performance, stability, and reliability, while related, are 3 different goals.
-
-If you are reading this, you are here to achieve one or all 3 goals.
-
-Here's the short recipe to test your system for performance, stability, and reliability.
-
-1. Start small. Run a smoke test.
-2. If your smoke test succeeded, increase the load and run a small load test.
-3. If your load test worked as expected, automate it. Automate early. Consistency is key.
-4. Monitor your performance over time. If you automated by scheduling your tests to run nightly,
-   observe the performance changes over time.
-5. Add thresholds to your load test to fail when the performance decreases below your expectations.
-   Setup notifications on failure.
-6. Run significant Load Tests nightly in your Staging Environment to make sure your performance
-   didn't degrade due to recent code changes.
-7. Run a Stress Test to verify the limits of your system, and it's stability under extreme
-   conditions.
-8. Run Soak Test to verify the reliability of your system over an extended period of time.
--->
+Comience con [Smoke test (Prueba de Humo)](/es/tipos-de-prueba/smoke-testing/) y vea lo fácil que es hacer su primera prueba de carga.

--- a/src/data/markdown/translated-guides/es/05 Test Types/01 Smoke Testing.md
+++ b/src/data/markdown/translated-guides/es/05 Test Types/01 Smoke Testing.md
@@ -67,4 +67,4 @@ Si su prueba de humo produjo algún error, debe corregir el script o arreglar su
 La salida de k6 debe ser similar a esta:
 ![Smoke test Terminal Output](./images/smoke-test-terminal-output.png)
 
-Una vez que su prueba de humo muestra 0 errores, como en la captura de pantalla anterior, puede ir al siguiente paso y ejecutar un [load test](/test-types/load-testing) para evaluar el rendimiento de su sistema.
+Una vez que su prueba de humo muestra 0 errores, como en la captura de pantalla anterior, puede ir al siguiente paso y ejecutar un [load test](/es/tipos-de-prueba/load-testing/) para evaluar el rendimiento de su sistema.

--- a/src/data/markdown/translated-guides/es/05 Test Types/02 Load Testing.md
+++ b/src/data/markdown/translated-guides/es/05 Test Types/02 Load Testing.md
@@ -21,7 +21,7 @@ Debe ejecutar la prueba de carga para:
 1 - Evaluar el rendimiento actual de su sistema bajo carga típica y máxima.
 2 - Asegurarse de que cumple continuamente los estándares de rendimiento a medida que realiza cambios en su sistema (código e infraestructura).
 
-Es probable que tenga algún conocimiento sobre la cantidad de tráfico que su sistema está viendo en promedio y durante las horas pico. Esta información será útil a la hora de decidir cuáles deben ser sus objetivos de rendimiento, es decir, cómo configurar [thresholds de rendimiento](/using-k6/thresholds).
+Es probable que tenga algún conocimiento sobre la cantidad de tráfico que su sistema está viendo en promedio y durante las horas pico. Esta información será útil a la hora de decidir cuáles deben ser sus objetivos de rendimiento, es decir, cómo configurar [thresholds de rendimiento](/es/usando-k6/thresholds/).
 
 Digamos que estás viendo alrededor de 60 usuarios concurrentes en promedio y 100 usuarios durante las horas pico de operación.
 Probablemente sea importante para usted cumplir los objetivos de rendimiento tanto en horas normales como en horas punta, por lo que se recomienda configurar la prueba de carga teniendo en cuenta la carga alta: 100 usuarios en este caso
@@ -96,7 +96,7 @@ Le recomendamos que incluya siempre una etapa de rampa ascendente en todas sus p
 
 
 También puede ir un paso más allá y configurar la prueba de carga para que se asemeje más a sus condiciones normales y de pico. En ese caso, podría configurar la prueba de carga para que se mantenga en 60 usuarios durante la mayor parte del día, y que aumente a 100 usuarios durante las horas de mayor actividad, para luego disminuir a la carga normal.
-Asegúrese de no sobrepasar su número normal de VUs - eso no es una prueba de carga, es una [prueba de estrés (stress test)](/test-types/stress-testing).
+Asegúrese de no sobrepasar su número normal de VUs - eso no es una prueba de carga, es una [prueba de estrés (stress test)](/es/tipos-de-prueba/stress-testing).
 
 <CodeGroup labels={["ramp-up-scenario.js"]} lineNumbers={[true]}>
 
@@ -140,4 +140,4 @@ Thresholds son una forma de describir sus expectativas de manera formal, y evalu
 >
 > Si es la primera vez que ejecuta pruebas de carga, empiece con algo pequeño. Es posible que su aplicación e infraestructura no sean tan sólidas como cree. Hemos tenido miles de usuarios que han ejecutado pruebas de carga que rápidamente colapsaron sus aplicaciones (o entornos de ensayo).
 
-Si su sistema se bloquea bajo una prueba de carga, significa que su prueba de carga se ha transformado en una [prueba de estrés (stress test)](/test-types/stress-testing), que es el siguiente tipo que vamos a tratar.
+Si su sistema se bloquea bajo una prueba de carga, significa que su prueba de carga se ha transformado en una [prueba de estrés (stress test)](/es/tipos-de-prueba/stress-testing), que es el siguiente tipo que vamos a tratar.

--- a/src/data/markdown/translated-guides/es/05 Test Types/03 Stress testing.md
+++ b/src/data/markdown/translated-guides/es/05 Test Types/03 Stress testing.md
@@ -210,4 +210,4 @@ Una vez que su sistema es a prueba de estrés, es posible que desee ejecutar una
 
 ## Vea también
 
-- [Ejecución de pruebas a gran escala](/testing-guides/running-large-tests)
+- [Ejecución de pruebas a gran escala](/es/guias-de-prueba/pruebas-a-gran-escala/)

--- a/src/data/markdown/translated-guides/es/05 Test Types/05 Soak Testing.md
+++ b/src/data/markdown/translated-guides/es/05 Test Types/05 Soak Testing.md
@@ -3,7 +3,7 @@ title: 'Soak testing'
 excerpt: 'El soak test descubre los problemas de rendimiento y fiabilidad derivados de un sistema sometido a presión durante un periodo prolongado.'
 ---
 
-Mientras que las [pruebas de carga (load tests)](/test-types/load-testing) se centran principalmente en la evaluación del rendimiento, y las [pruebas de estrés (stress tests)](/test-types/stress-testing) en la estabilidad del sistema en condiciones extremas, las soak Tests (Pruebas de durabilidad) se centran en la fiabilidad a largo plazo.
+Mientras que las [pruebas de carga (load tests)](/es/tipos-de-prueba/load-testing/) se centran principalmente en la evaluación del rendimiento, y las [pruebas de estrés (stress tests)](/es/tipos-de-prueba/stress-testing) en la estabilidad del sistema en condiciones extremas, las soak Tests (Pruebas de durabilidad) se centran en la fiabilidad a largo plazo.
 
 El soak test descubre los problemas de rendimiento y fiabilidad derivados de un sistema sometido a presión durante un periodo prolongado.
 
@@ -88,4 +88,4 @@ Soak Testing son el último gran paso en el camino hacia la construcción de sis
 
 ## Vea también
 
-- [Ejecución de pruebas a gran escala](/testing-guides/running-large-tests)
+- [Ejecución de pruebas a gran escala](/es/guias-de-prueba/pruebas-a-gran-escala/)

--- a/src/data/markdown/translated-guides/es/06 Testing Guides/01 API load testing.md
+++ b/src/data/markdown/translated-guides/es/06 Testing Guides/01 API load testing.md
@@ -22,7 +22,7 @@ Los binarios de k6 están disponibles para varias plataformas, por lo que ya no 
 $ k6 run script.js
 ```
 
-Usando este comando, puede ejecutar su script de prueba de carga y agregarle carga a el API. Como ya estás en la documentación, asegúrate de buscar los detalles que se adapten a tu caso de uso. Para darte un ejemplo, echa un vistazo al siguiente script, tomado de la sección [Peticiones HTTP](/using-k6/http-requests) de la documentación. Utiliza la [API k6/http](/javascript-api/k6-http) para realizar una solicitud de prueba de carga. Puedes jugar fácilmente con el ejemplo para crear tu propio script. Las siguientes secciones describen cómo hacer una prueba de carga, ya sea forzando un endpoint o probando el flujo de usuarios (escenario).
+Usando este comando, puede ejecutar su script de prueba de carga y agregarle carga a el API. Como ya estás en la documentación, asegúrate de buscar los detalles que se adapten a tu caso de uso. Para darte un ejemplo, echa un vistazo al siguiente script, tomado de la sección [Peticiones HTTP](/es/usando-k6/peticiones-http/) de la documentación. Utiliza la [API k6/http](/javascript-api/k6-http) para realizar una solicitud de prueba de carga. Puedes jugar fácilmente con el ejemplo para crear tu propio script. Las siguientes secciones describen cómo hacer una prueba de carga, ya sea forzando un endpoint o probando el flujo de usuarios (escenario).
 
 ### Benchmarking un endpoint
 
@@ -138,7 +138,7 @@ export default function () {
 
 Históricamente, hay dos tipos de categorías de herramientas de pruebas de carga: con script y sin script. Las herramientas que no dependen de un script generan peticiones a uno o varios endpoints sin ninguna correlación entre las peticiones, proporcionando la opción de definir una tasa de peticiones constante para llegar a un endpoint. Por otro lado, las herramientas que dependen de un script suelen estar diseñadas para facilitar las pruebas de flujo de usuarios, proporcionando así la opción de configurar el número de usuarios virtuales para establecer la carga de su prueba. k6 pertenece a esta categoría.
 
-k6 se incluye la función de [scenarios](/using-k6/scenarios), donde se pueden configurar múltiples escenarios y modelar diferentes patrones de tráfico. El motor de ejecución de k6 ha sido completamente renovado y ahora incluye soporte para diferentes [executors](/using-k6/scenarios#executors) en cada escenario. Ahora puede utilizar el ejecutor de tasa de llegada constante para [generar una tasa de solicitud constante](https://k6.io/blog/how-to-generate-a-constant-request-rate-with-the-new-scenarios-api).
+k6 se incluye la función de [scenarios](/es/usando-k6/escenarios/), donde se pueden configurar múltiples escenarios y modelar diferentes patrones de tráfico. El motor de ejecución de k6 ha sido completamente renovado y ahora incluye soporte para diferentes [executors](/es/usando-k6/escenarios/executors/) en cada escenario. Ahora puede utilizar el ejecutor de tasa de llegada constante para [generar una tasa de solicitud constante](https://k6.io/blog/how-to-generate-a-constant-request-rate-with-the-new-scenarios-api).
 
 ## Creación de las pruebas
 
@@ -174,12 +174,12 @@ Swagger/OpenAPI es una buena manera de diseñar, documentar y probar tus APIs. H
 
 **HAR-to-k6**
 
-Los archivos HAR son registros de navegación grabados que pueden exportarse como archivos y reproducirse posteriormente. La especificación de los archivos HAR define el formato del archivo, que es básicamente un archivo JSON con varios objetos que contienen peticiones a diferentes recursos. Este archivo se puede convertir en un script de k6 utilizando la herramienta [HAR-to-k6](https://github.com/loadimpact/har-to-k6). Dado que los archivos HAR contienen peticiones a cada uno de los recursos que el navegador obtiene, no se recomienda utilizar el script convertido intacto, sino que se recomienda revisarlo para eliminar las peticiones innecesarias a las CDN de prueba de carga y otros archivos estáticos. Generalmente, grabar las sesiones de los usuarios no suele ser la mejor manera de hacer pruebas de carga de las APIs, ya que crea más elementos que las peticiones reales y se utiliza más para [probar la carga de un sitio web](/testing-guides/load-testing-websites). No obstante, puedes aprovecharlo, pero debes tener cuidado, ya que podría llevarte a probar sistemas no relacionados con tu API.
+Los archivos HAR son registros de navegación grabados que pueden exportarse como archivos y reproducirse posteriormente. La especificación de los archivos HAR define el formato del archivo, que es básicamente un archivo JSON con varios objetos que contienen peticiones a diferentes recursos. Este archivo se puede convertir en un script de k6 utilizando la herramienta [HAR-to-k6](https://github.com/loadimpact/har-to-k6). Dado que los archivos HAR contienen peticiones a cada uno de los recursos que el navegador obtiene, no se recomienda utilizar el script convertido intacto, sino que se recomienda revisarlo para eliminar las peticiones innecesarias a las CDN de prueba de carga y otros archivos estáticos. Generalmente, grabar las sesiones de los usuarios no suele ser la mejor manera de hacer pruebas de carga de las APIs, ya que crea más elementos que las peticiones reales y se utiliza más para [probar la carga de un sitio web](/es/guias-de-prueba/pruebas-de-carga-a-sitios-web/). No obstante, puedes aprovecharlo, pero debes tener cuidado, ya que podría llevarte a probar sistemas no relacionados con tu API.
 
 
 **Fiddler-to-k6**
 
-Originalmente llamado [FiddlerToLoadImpact](https://github.com/loadimpact/FiddlerToLoadImpact), puede ser usado para exportar tus grabaciones de fiddler a un script de k6. Obviamente, necesitas tener Fiddler instalado para que funcione. Esta herramienta también crea grabaciones HAR, así que lo mismo ocurre con esto, en el sentido de que no es apto para las pruebas de carga de las APIs, sino que está hecho para las pruebas de carga del sitio web, así que tenga esto en cuenta. Para más información, consulte la [guía de grabación de sesiones](/using-k6/session-recording-har-support).
+Originalmente llamado [FiddlerToLoadImpact](https://github.com/loadimpact/FiddlerToLoadImpact), puede ser usado para exportar tus grabaciones de fiddler a un script de k6. Obviamente, necesitas tener Fiddler instalado para que funcione. Esta herramienta también crea grabaciones HAR, así que lo mismo ocurre con esto, en el sentido de que no es apto para las pruebas de carga de las APIs, sino que está hecho para las pruebas de carga del sitio web, así que tenga esto en cuenta. Para más información, consulte la [guía de grabación de sesiones](/es/creacion-de-pruebas/grabar-una-sesion/).
 
 ## Diferentes tipos de pruebas de carga para las APIs
 
@@ -187,23 +187,23 @@ Como hemos estado mostrando en la introducción, es crucial hacer pruebas de API
 
 Puede hacer pruebas de API de múltiples maneras, cada una de ellas pertenece a un tipo de prueba particular y produce un tipo de carga diferente.
 
-- [Smoke test](/test-types/smoke-testing)
-- [Load test](/test-types/load-testing)
-- [Stress test](/test-types/stress-testing)
-- [Spike test](/test-types/stress-testing#spike-testing)
-- [Soak test](/test-types/soak-testing)
+- [Smoke test](/es/tipos-de-prueba/smoke-testing/)
+- [Load test](/es/tipos-de-prueba/load-testing)
+- [Stress test](/es/tipos-de-prueba/stress-testing)
+- [Spike test](/es/tipos-de-prueba/stress-testing#spike-testing)
+- [Soak test](/es/tipos-de-prueba/soak-testing)
 
 ## Consideraciones sobre las pruebas de carga de la API
 
 ### Identifique sus objetivos
 
-Tener un objetivo claro es de suma importancia a la hora de ejecutar una prueba de carga en sus APIs. Al igual que el tipo de prueba de carga que desea utilizar, también debe identificar sus objetivos para esperar resultados correctos. Por ejemplo, no puede esperar que el API funcione muy bien bajo una carga pesada, si solo realiza una prueba de humo. Por lo tanto, debe establecer objetivos bien definidos y ajustar su prueba de carga para satisfacer sus expectativas. Por lo general, sus objetivos son cumplir con los niveles de servicios (SLO), que pueden estar definidos en un acuerdo de nivel de servicio (SLA), formal o informalmente, entre usted y la otra parte, por ejemplo, sus usuarios. Afortunadamente, estos umbrales pueden ser probados utilizando k6, que tiene un rico conjunto de métricas incorporadas y personalizadas, que pueden ser probadas con [Thresholds](/using-k6/thresholds). Antes de escribir y eventualmente ejecutar su prueba, reserve algún tiempo para pensar en sus SLOs y luego trate de diseñar su prueba, para que cumpla con sus requisitos y las expectativas de sus clientes.
+Tener un objetivo claro es de suma importancia a la hora de ejecutar una prueba de carga en sus APIs. Al igual que el tipo de prueba de carga que desea utilizar, también debe identificar sus objetivos para esperar resultados correctos. Por ejemplo, no puede esperar que el API funcione muy bien bajo una carga pesada, si solo realiza una prueba de humo. Por lo tanto, debe establecer objetivos bien definidos y ajustar su prueba de carga para satisfacer sus expectativas. Por lo general, sus objetivos son cumplir con los niveles de servicios (SLO), que pueden estar definidos en un acuerdo de nivel de servicio (SLA), formal o informalmente, entre usted y la otra parte, por ejemplo, sus usuarios. Afortunadamente, estos umbrales pueden ser probados utilizando k6, que tiene un rico conjunto de métricas incorporadas y personalizadas, que pueden ser probadas con [Thresholds](/es/usando-k6/thresholds/). Antes de escribir y eventualmente ejecutar su prueba, reserve algún tiempo para pensar en sus SLOs y luego trate de diseñar su prueba, para que cumpla con sus requisitos y las expectativas de sus clientes.
 
 ### Empezar poco a poco y construir el  script 
 
 Es importante tener un conjunto predefinido de objetivos y expectativas, pero no es bueno intentar cumplirlos todos a la vez. Cuanto mayor sea tu lista de objetivos, menos probable será tu capacidad de hacer las cosas bien a la primera. Así que empieza por lo pequeño, por ejemplo, escribe y ejecuta una prueba para uno o dos endpoints de la API. Intenta experimentar con diferentes configuraciones y entornos, luego puedes basarte en eso y ejecutar grandes pruebas que abarquen varias horas y tengan miles de usuarios virtuales y cientos de miles de peticiones por segundo
 
-Los ejemplos muy sencillos de la sección [ejecutando k6](https://k6.io/docs/getting-started/running-k6).
+Los ejemplos muy sencillos de la sección [ejecutando k6](/es/empezando/ejecucion-de-k6/).
 
 ### Correlación y parametrización de datos
 
@@ -219,7 +219,7 @@ Para más información, consulte el [post en el foro de la comunidad de k6](http
 
 ### Agrupación de las URLs
 
-Por defecto, k6 imprimirá la información del tiempo de ejecución y los resultados generales a la salida estándar, `stdout`, mientras la prueba se esté ejecutando, y también imprimirá un resumen después de que la prueba haya terminado. Puede dar salida a datos de resultados más granulares utilizando módulos de salida especiales, uno de ellos es la [salida JSON](/getting-started/results-output/json). El contenido de los registros en la salida incluye muchas piezas de información útil como varias métricas y algunas de esas métricas incluyen la URL de las peticiones que ha realizado.
+Por defecto, k6 imprimirá la información del tiempo de ejecución y los resultados generales a la salida estándar, `stdout`, mientras la prueba se esté ejecutando, y también imprimirá un resumen después de que la prueba haya terminado. Puede dar salida a datos de resultados más granulares utilizando módulos de salida especiales, uno de ellos es la [salida JSON](/es/visualizacion-de-resultados/json/). El contenido de los registros en la salida incluye muchas piezas de información útil como varias métricas y algunas de esas métricas incluyen la URL de las peticiones que ha realizado.
 
 A veces es necesario hacer muchas peticiones de APIs similares para leer o crear muchos recursos del mismo tipo. Como se muestra en el siguiente ejemplo, se obtendrán 100 entradas con peticiones únicas. Cada una de estas peticiones creará una métrica y tendrá la URL completa dentro de la métrica. Esto plantea un problema para la agregación de datos, ya sea en nuestra plataforma en la nube o en su propia pila de pruebas de carga de la API. El problema es que todas las métricas para cada una de estas URLs estarán separadas y serán agregadas individualmente, porque son diferentes en su campo de id. También crea varios registros innecesarios en la salida.
 
@@ -232,7 +232,7 @@ for (var id = 1; id <= 100; id++) {
 // tags.name="http://example.com/posts/2",
 ```
 
-Hay una forma de evitar la creación de muchas métricas para la misma URL. Se llama [agrupación de URLs](/using-k6/http-requests#section-url-grouping), y al usarla evitarás crear métricas separadas para la misma URL. Se trata simplemente de utilizar una etiqueta que debes añadir a los [parámetros](/javascript-api/k6-http/params) de tus peticiones.
+Hay una forma de evitar la creación de muchas métricas para la misma URL. Se llama [agrupación de URLs](/es/usando-k6/peticiones-http/#agrupamiento-de-las-urls), y al usarla evitarás crear métricas separadas para la misma URL. Se trata simplemente de utilizar una etiqueta que debes añadir a los [parámetros](/javascript-api/k6-http/params) de tus peticiones.
 
 ```javascript
 for (var id = 1; id <= 100; id++) {

--- a/src/data/markdown/translated-guides/es/06 Testing Guides/02 Automated performance testing.md
+++ b/src/data/markdown/translated-guides/es/06 Testing Guides/02 Automated performance testing.md
@@ -38,7 +38,7 @@ Desde el punto de vista de la capacidad de percepción humana, los siguientes pu
 > - 1,0 segundo es el límite para que el flujo de pensamiento del usuario permanezca ininterrumpido, aunque el usuario notará el retraso. Normalmente, no es necesaria ninguna información especial durante los retrasos superiores a 0,1 pero inferiores a 1,0 segundos, pero el usuario pierde la sensación de operar directamente con los datos.
 > - 10 segundos es el límite para mantener la atención del usuario en el diálogo. En el caso de retrasos más largos, los usuarios querrán realizar otras tareas mientras esperan a que el ordenador termine, por lo que deben recibir una retroalimentación que les indique cuándo espera el ordenador que terminen. La retroalimentación durante el retraso es especialmente importante si el tiempo de respuesta puede ser muy variable, ya que entonces los usuarios no sabrán qué esperar.
 
-Una vez que los objetivos están claros, hay que codificarlos como [Thresholds](/using-k6/thresholds), que es el mecanismo por el que se especifican los criterios de aprobado/reprobado en k6. Más adelante se habla de ello.
+Una vez que los objetivos están claros, hay que codificarlos como [Thresholds](/es/usando-k6/thresholds/), que es el mecanismo por el que se especifican los criterios de aprobado/reprobado en k6. Más adelante se habla de ello.
 
 ## ¿Cómo automatizar las pruebas de performance?
 
@@ -62,8 +62,8 @@ Además, también tenemos disponibles guías para [instalar k6 en herramientas C
 
 Si aún no ha creado casos de prueba para su sistema, le sugerimos que lea una de nuestras guías para crear pruebas para sitios web y APIs/microservicios:
 
-- [Guía de pruebas para sitios web](/testing-guides/load-testing-websites)
-- [Guía de pruebas de API](/testing-guides/api-load-testing)
+- [Guía de pruebas para sitios web](/es/guias-de-prueba/pruebas-de-carga-a-sitios-web/)
+- [Guía de pruebas de API](/es/guias-de-prueba/pruebas-de-carga-para-apis/)
 
 En general, cuando se crean casos de prueba, la regla de oro es empezar con algo pequeño y luego ampliarlo desde ese punto de partida. Identifique las transacciones más críticas para el negocio en su sistema y escriba casos de prueba que cubran esa parte del sistema.
 
@@ -73,11 +73,11 @@ Una de las mejores prácticas que aconsejamos a los usuarios y clientes es el co
 
 **Modules**
 
-Una vez que haya adquirido suficiente experiencia en la creación de pruebas, le aconsejamos encarecidamente que [moduralize sus pruebas](/using-k6/modules) para que la lógica/patrones comunes sean reutilizables entre los miembros de su equipo y las diferentes pruebas de rendimiento.
+Una vez que haya adquirido suficiente experiencia en la creación de pruebas, le aconsejamos encarecidamente que [moduralize sus pruebas](/es/usando-k6/modulos/) para que la lógica/patrones comunes sean reutilizables entre los miembros de su equipo y las diferentes pruebas de rendimiento.
 
 ## 3. Criterios para éxito/fallo
 
-Cada paso en una línea de automatización pasa o falla. Como se mencionó en `Conozca sus objetivos`, el mecanismo por el cual k6 decide si una prueba ha pasado o fallado se llama [Thresholds](/using-k6/thresholds). Sin sus objetivos codificados como umbrales no hay manera de que k6 sepa realmente si su prueba debe ser considerada un éxito o un fracaso.
+Cada paso en una línea de automatización pasa o falla. Como se mencionó en `Conozca sus objetivos`, el mecanismo por el cual k6 decide si una prueba ha pasado o fallado se llama [Thresholds](/es/usando-k6/modulos/). Sin sus objetivos codificados como umbrales no hay manera de que k6 sepa realmente si su prueba debe ser considerada un éxito o un fracaso.
 
 Un Thresholds básico en el percentil 95 de la métrica del tiempo de respuesta tiene este aspecto:
 
@@ -144,7 +144,7 @@ Tenga en cuenta estos tres factores a la hora de elegir la mejor solución para 
 
 Una regla general es que cuanto más corta sea la "duración de la iteración de la VU", más frecuente será la ejecución de las pruebas sin introducir largos retrasos en el ciclo de retroalimentación del desarrollo, ni bloquear el acceso de los compañeros de equipo a los entornos de preproducción compartidos.
 
-Una rápida recapitulación del artículo sobre el [ciclo de vida de las pruebas](/using-k6/test-life-cycle):
+Una rápida recapitulación del artículo sobre el [ciclo de vida de las pruebas](/es/usando-k6/etapas-de-un-test/):
 
 
 ```javascript

--- a/src/data/markdown/translated-guides/es/06 Testing Guides/03 Load testing websites.md
+++ b/src/data/markdown/translated-guides/es/06 Testing Guides/03 Load testing websites.md
@@ -75,11 +75,11 @@ Con esta información, es el momento de analizar la frecuencia de uso, el valor 
 
 A continuación, debe decidir qué tipos de pruebas de carga ejecutar. Consulte los siguientes artículos para obtener más información:
 
-- [Smoke test](/test-types/smoke-testing)
-- [Load test](/test-types/load-testing)
-- [Stress test](/test-types/stress-testing)
-- [Spike test](/test-types/stress-testing#spike-testing)
-- [Soak test](/test-types/soak-testing)
+- [Smoke test](/es/tipos-de-prueba/smoke-testing)
+- [Load test](/es/tipos-de-prueba/load-testing)
+- [Stress test](/es/tipos-de-prueba/stress-testing)
+- [Spike test](/es/tipos-de-prueba/stress-testing#spike-testing)
+- [Soak test](/es/tipos-de-prueba/soak-testing)
 
 ### Calcular el número de usuarios concurrentes
 
@@ -106,7 +106,7 @@ Las pruebas de carga deben imitar los flujos de los usuarios lo más fielmente p
 
 El proceso de creación de este tipo de pruebas de carga podría ser engorroso. Pero la grabación de una sesión de usuario podría facilitarle el trabajo de iniciar la creación de la prueba.
 
-Consulte la [guía de grabación de sesiones](/test-authoring/recording-a-session) para obtener más información sobre cómo autogenerar su prueba de carga a partir de una sesión de usuario.
+Consulte la [guía de grabación de sesiones](/es/creacion-de-pruebas/grabar-una-sesion/grabador-de-navegador/) para obtener más información sobre cómo autogenerar su prueba de carga a partir de una sesión de usuario.
 
 ### No incluya solicitudes de terceros
 
@@ -158,7 +158,7 @@ Por defecto, las métricas estandarizadas de una herramienta de pruebas de carga
 
 Los diferentes tipos de recursos podrían comportarse de forma muy diferente y podrían hacer que el valor de las métricas agregadas no tuviera sentido.
 
-Si desea filtrar sus métricas en función de los diferentes tipos de solicitudes, considere la posibilidad de utilizar la función de [etiquetado (tags)](/using-k6/tags-and-groups#tags).
+Si desea filtrar sus métricas en función de los diferentes tipos de solicitudes, considere la posibilidad de utilizar la función de [etiquetado (tags)](/es/usando-k6/tags-y-groups/#tags).
 
 <CodeGroup labels={[]}>
 
@@ -170,7 +170,7 @@ http.get('http://myweb.com/images/logo.png', { tags: { assets: 'image' } });
 
 ### Agrupar las diferentes páginas web
 
-[Groups](/using-k6/tags-and-groups#groups) ayudan a organizar su prueba de carga en torno a una lógica común. Cuando una prueba de carga simula un escenario de un usuario que visita varias páginas, es una buena práctica configurar un grupo para cada página web para organizar su prueba de carga y facilitar la visualización de los resultados de su prueba.
+[Groups](/es/usando-k6/tags-y-groups/#groups) ayudan a organizar su prueba de carga en torno a una lógica común. Cuando una prueba de carga simula un escenario de un usuario que visita varias páginas, es una buena práctica configurar un grupo para cada página web para organizar su prueba de carga y facilitar la visualización de los resultados de su prueba.
 
 <CodeGroup labels={[]}>
 
@@ -187,8 +187,8 @@ group('login page', function () {
 
 ## Véase también
 
-- [k6 no ejecuta un navegador](/#what-k6-does-not)
-- [Guía de grabación de sesiones ](/using-k6/session-recording-har-support)
+- [k6 no ejecuta un navegador](/#¿que-no-hace-k6)
+- [Guía de grabación de sesiones ](/es/creacion-de-pruebas/grabar-una-sesion/)
 - [Determining concurrent users in your load tests](https://k6.io/blog/monthly-visits-concurrent-users)
 - [Data correlation in your test script](/examples/correlation-and-dynamic-data)
 - Interacting with HTML content: [parseHTML](/javascript-api/k6-html/parsehtml-src) and [Selection.find](/javascript-api/k6-html/selection/selection-find-selector)

--- a/src/data/markdown/translated-guides/es/06 Testing Guides/04 Running large tests.md
+++ b/src/data/markdown/translated-guides/es/06 Testing Guides/04 Running large tests.md
@@ -29,7 +29,7 @@ Estos comandos permiten reutilizar las conexiones de red, aumentar el límite de
 
 Para aplicar estos cambios, puedes pegar estos comandos como usuario root antes de ejecutar una prueba k6 o cambiar los archivos de configuración en tu sistema operativo.
 
-Para obtener información detallada sobre estos ajustes, las instrucciones de macOS y cómo hacerlos permanentes, consulta nuestro artículo ["Ajuste del sistema operativo"](/misc/fine-tuning-os).
+Para obtener información detallada sobre estos ajustes, las instrucciones de macOS y cómo hacerlos permanentes, consulta nuestro artículo ["Ajuste del sistema operativo"](/es/misc/optimizar-el-sistema-operativo/).
 
 ## Consideraciones sobre el hardware
 
@@ -384,7 +384,7 @@ Los usuarios suelen buscar el modo de ejecución distribuida para ejecutar prueb
 - Simular la carga desde múltiples ubicaciones simultáneamente.
 - Escalar la carga de su prueba más allá de lo que puede soportar una sola máquina.
 
-En k6, puede dividir la carga de una prueba entre varias instancias de k6 utilizando la opción [execution-segment](/using-k6/options#execution-segment). Por ejemplo:
+En k6, puede dividir la carga de una prueba entre varias instancias de k6 utilizando la opción [execution-segment](/es/usando-k6/opciones/#execution-segment). Por ejemplo:
 
 <CodeGroup labels={["Two machines", "Three machines", "Four machines"]}>
 
@@ -422,15 +422,15 @@ Sin embargo -en este momento  el modo de ejecución distribuido de k6 no es del 
 
 ## Pruebas a gran escala en k6 Cloud
 
-[k6 Cloud](https://k6.io/cloud) nuestra oferta comercial proporciona una solución instantánea para ejecutar pruebas a gran escala, entre otras [ventajas](https://k6.io/docs/cloud#how-can-it-help-me).
+[k6 Cloud](https://k6.io/cloud) nuestra oferta comercial proporciona una solución instantánea para ejecutar pruebas a gran escala, entre otras [ventajas](/cloud#how-can-it-help-me).
 
 Si no está seguro de qué solución, OSS o Cloud, se ajusta mejor a su proyecto, le recomendamos que lea el [siguiente artículo](https://k6.io/what-to-consider-when-building-or-buying-a-load-testing-solution)h para saber más sobre los riesgos y las características a tener en cuenta a la hora de crear una solución escalable.
 
 
 ## Véase también
 
-- [Fine tuning OS](/misc/fine-tuning-os)
-- [JavaScript Compatibility Mode](/using-k6/javascript-compatibility-mode)
+- [Fine tuning OS](/es/misc/optimizar-el-sistema-operativo)
+- [JavaScript Compatibility Mode](/es/usando-k6/javascript-compatibility-mode/)
 - [A biased comparison of the best open source load testing tools](https://k6.io/blog/comparing-best-open-source-load-testing-tools)
 - [k6 Cloud Pricing - soak and large-scale tests](https://k6.io/pricing#larger-tests)
 - [White paper: what to consider when building or buying a load testing solution](https://k6.io/what-to-consider-when-building-or-buying-a-load-testing-solution)

--- a/src/data/markdown/translated-guides/es/07 Misc/03 Fine tuning OS.md
+++ b/src/data/markdown/translated-guides/es/07 Misc/03 Fine tuning OS.md
@@ -305,7 +305,7 @@ Dependiendo de la prueba particular de k6: número máximo de VUs utilizadas, n�
 
 Como referencia, cuente que cada instancia de VU requiere entre 1MB y 5MB de RAM, dependiendo de la complejidad de su script y sus dependencias. Esto es aproximadamente entre `GB y 5GB de RAM del sistema requerido para una prueba de 1.000 VU, así que asegúrese de que hay suficiente RAM física disponible para satisfacer las demandas de su prueba.
 
-Si necesita disminuir el uso de RAM, puede utilizar la opción `--compatibility-mode=base`. Más información en [JavaScript Compatibility Mode](/using-k6/javascript-compatibility-mode).
+Si necesita disminuir el uso de RAM, puede utilizar la opción `--compatibility-mode=base`. Más información en [JavaScript Compatibility Mode](/es/usando-k6/javascript-compatibility-mode/).
 
 ### Memoria virtual
 
@@ -333,5 +333,5 @@ Por ejemplo, puede configurar su aplicación para que se ejecute en los puertos 
 
 ## Véase también
 
-- [Ejecución de pruebas a gran escala](/testing-guides/running-large-tests)
-- [JavaScript Compatibility Mode](/using-k6/javascript-compatibility-mode)
+- [Ejecución de pruebas a gran escala](/es/guias-de-prueba/pruebas-a-gran-escala/)
+- [JavaScript Compatibility Mode](/es/usando-k6/javascript-compatibility-mode/)

--- a/src/data/markdown/translated-guides/es/07 Misc/06 Archive.md
+++ b/src/data/markdown/translated-guides/es/07 Misc/06 Archive.md
@@ -21,7 +21,7 @@ $ k6 run script.js
 
 </CodeGroup>
 
-Ahora bien, si sustituye `k6 run` por `k6 archive`, k6 ejecutará la fase de [inicio del código](/using-k6/test-life-cycle) para determinar qué archivos JS se están importando y qué archivos de datos se están [open()](/javascript-api/init-context/open-filepath-mode) y agrupa todos los archivos en un archivo tar:
+Ahora bien, si sustituye `k6 run` por `k6 archive`, k6 ejecutará la fase de [inicio del código](/es/usando-k6/etapas-de-un-test/) para determinar qué archivos JS se están importando y qué archivos de datos se están [open()](/javascript-api/init-context/open-filepath-mode) y agrupa todos los archivos en un archivo tar:
 
 
 <CodeGroup labels={[]} lineNumbers={[true]}>
@@ -65,7 +65,7 @@ k6 ofrece un servicio comercial para ejecutar pruebas de carga a gran escala y d
 
 ### Ejecución en clúster  (_futuro_)
 
-En el futuro (véase nuestra [hoja de ruta](https://github.com/loadimpact/k6/wiki/Roadmap)) k6 soportará un modo de ejecución en clúster que permitirá la ejecución de pruebas en más de un nodo. Este modo de ejecución también es probable que haga uso de la funcionalidad de archivo para distribuir los archivos de prueba a todos los nodos participantes.
+En el futuro (véase nuestro [Roadmap](https://github.com/loadimpact/k6/wiki/Roadmap)) k6 soportará un modo de ejecución en clúster que permitirá la ejecución de pruebas en más de un nodo. Este modo de ejecución también es probable que haga uso de la funcionalidad de archivo para distribuir los archivos de prueba a todos los nodos participantes.
 
 ## Contenido de un fichero de archivo
 

--- a/src/i18n/i18n-config.js
+++ b/src/i18n/i18n-config.js
@@ -1,5 +1,4 @@
 const I18N_CONFIG = {
-  disableRedirectToSelectedLanguage: false,
   hideEsFromAlgoliaSearch: false,
   hideLanguageToggle: false,
   hideEsFromRobots: false,

--- a/src/layouts/doc-layout/doc-layout.view.js
+++ b/src/layouts/doc-layout/doc-layout.view.js
@@ -233,20 +233,10 @@ export const DocLayout = ({
 
   const location = typeof window !== 'undefined' ? window.pathname : '';
 
-  // if another language was selected and current page has a translated version in that language,
-  // redirect to it
+  // if user opens a page in a different language from what was chosen, save new language
   React.useEffect(() => {
-    if (I18N_CONFIG.disableRedirectToSelectedLanguage) {
-      return;
-    }
-
-    if (
-      pageTranslations &&
-      locale &&
-      pageTranslations[locale] &&
-      locale !== urlLocale
-    ) {
-      navigate(pageTranslations[locale].path, { replace: true });
+    if (locale && locale !== urlLocale) {
+      setLocale(urlLocale);
     }
   }, [location]);
 


### PR DESCRIPTION
This PR removes redirect to translated version and adds localized ES links to top-level guides page (https://docs.k6.io/es)