### PR TITLE
Fix little typo in example code

### DIFF
--- a/src/data/markdown/translated-guides/en/02 Using k6/10 Protocols/02 WebSockets.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/10 Protocols/02 WebSockets.md
@@ -175,7 +175,7 @@ export default function () {
 
     socket.on('error', (e) => {
       if (e.error() != 'websocket: close sent') {
-        console.log('An unexpected error occured: ', e.error());
+        console.log('An unexpected error occurred: ', e.error());
       }
     });
 


### PR DESCRIPTION
Just a little typo I found during reading the examples.