### PR TITLE
Add jslib findBetween to docs

### DIFF
--- a/src/data/markdown/docs/02 javascript api/02 k6/sleep- t -.md
+++ b/src/data/markdown/docs/02 javascript api/02 k6/sleep- t -.md
@@ -36,7 +36,7 @@ Using the [k6-utils](https://jslib.k6.io/k6-utils/) library to specify a range b
 ```javascript
 import { sleep } from 'k6';
 import http from 'k6/http';
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 export default function () {
   http.get('https://k6.io');

--- a/src/data/markdown/docs/02 javascript api/11 jslib.md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib.md
@@ -24,7 +24,7 @@ import { check, sleep } from "k6";
 import jsonpath from "https://jslib.k6.io/jsonpath/1.0.2/index.js"
 import { randomIntBetween, 
          randomItem, 
-         uuidv4 } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+         uuidv4 } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 const testData = {
   user: {

--- a/src/data/markdown/docs/02 javascript api/11 jslib/01 utils.md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/01 utils.md
@@ -33,7 +33,7 @@ import { randomIntBetween,
          randomString,
          randomItem,
          uuidv4,
-         findBetween } from "./src/utils.js";
+         findBetween } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 export default function() {
 

--- a/src/data/markdown/docs/02 javascript api/11 jslib/01 utils.md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/01 utils.md
@@ -18,7 +18,7 @@ The `utils` module contains number of small utility functions useful in every da
 | [randomItem(array)](/javascript-api/jslib/utils/randomitem-array)  | Random item from a given array |
 | [randomString(length)](/javascript-api/jslib/utils/randomstring-length)  | Random string of a given length |
 | [uuidv4()](/javascript-api/jslib/utils/uuidv4)  | Random UUID v4 in a string representation |
-| [findBetween(content, left, right)](/javascript-api/jslib/utils/findbetween)  | Extract a string between two surrounding strings |
+| [findBetween(content, left, right)](/javascript-api/jslib/utils/findbetween-content-left-right)  | Extract a string between two surrounding strings |
 
 
 ## Simple example

--- a/src/data/markdown/docs/02 javascript api/11 jslib/01 utils.md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/01 utils.md
@@ -18,7 +18,7 @@ The `utils` module contains number of small utility functions useful in every da
 | [randomItem(array)](/javascript-api/jslib/utils/randomitem-array)  | Random item from a given array |
 | [randomString(length)](/javascript-api/jslib/utils/randomstring-length)  | Random string of a given length |
 | [uuidv4()](/javascript-api/jslib/utils/uuidv4)  | Random UUID v4 in a string representation |
-
+| [findBetween(content, left, right)](/javascript-api/jslib/utils/findbetween)  | Extract a string between two surrounding strings |
 
 
 ## Simple example
@@ -32,7 +32,8 @@ import http from 'k6/http';
 import { randomIntBetween, 
          randomString,
          randomItem,
-         uuidv4 } from "./src/utils.js";
+         uuidv4,
+         findBetween } from "./src/utils.js";
 
 export default function() {
 
@@ -42,6 +43,10 @@ export default function() {
     username: `user_${randomString(10)}@example.com`,  // random email address,
     password: uuidv4() // random password in form of uuid
   });
+
+  // find a string between two strings to grab the username:
+  let username = findBetween(res.body, '"username":"', '"');
+  console.log('username from response: ' + username);
 
   sleep(randomIntBetween(1, 5)); // sleep between 1 and 5 seconds.
 }

--- a/src/data/markdown/docs/02 javascript api/11 jslib/02 httpx.md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/02 httpx.md
@@ -55,7 +55,7 @@ This documentation is for the last version only. If you discover that some of th
 ```javascript
 import { fail } from 'k6';
 import { Httpx } from 'https://jslib.k6.io/httpx/0.0.3/index.js';
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 const USERNAME = `user${randomIntBetween(1, 100000)}@example.com`;  // random email address
 const PASSWORD = 'superCroc2021';

--- a/src/data/markdown/docs/02 javascript api/11 jslib/utils/01 randomIntBetween(min, max) copy.md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/utils/01 randomIntBetween(min, max) copy.md
@@ -25,7 +25,7 @@ Function returns a random number between the specified range. The returned value
 
 ```javascript
 import { sleep } from 'k6';
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 export default function() {
   // code ...

--- a/src/data/markdown/docs/02 javascript api/11 jslib/utils/02 randomItem(array).md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/utils/02 randomItem(array).md
@@ -23,7 +23,7 @@ Function returns a random item from an array.
 <CodeGroup labels={[]}>
 
 ```javascript
-import { randomItem } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+import { randomItem } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 let names = ['John', 'Jane', 'Bert', 'Ed'];
 

--- a/src/data/markdown/docs/02 javascript api/11 jslib/utils/03 randomString(length).md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/utils/03 randomString(length).md
@@ -23,7 +23,7 @@ Function returns a random string of a given length.
 <CodeGroup labels={[]}>
 
 ```javascript
-import { randomString } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+import { randomString } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 export default function() {
   let randomName = randomString(8);

--- a/src/data/markdown/docs/02 javascript api/11 jslib/utils/04 uuidv4().md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/utils/04 uuidv4().md
@@ -18,7 +18,7 @@ Function returns a random uuid v4 in a string form.
 <CodeGroup labels={[]}>
 
 ```javascript
-import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 export default function() {
   let randomUUID = uuidv4();

--- a/src/data/markdown/docs/02 javascript api/11 jslib/utils/05 findBetween(content, left, right).md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/utils/05 findBetween(content, left, right).md
@@ -1,0 +1,38 @@
+---
+title: 'findBetween(content, left, right)'
+description: 'findBetween function'
+excerpt: 'findBetween function'
+---
+
+Function that returns a string from between two other strings.
+
+| Parameter     | Type   | Description |
+| ------------- | ------ |  --- |
+| content  | string  | The string to search through (e.g. [Response.body](https://k6.io/docs/javascript-api/k6-http/response/)) |
+| left | string | The string immediately before the value to be extracted |
+| right | string | The string immediately after the value to be extracted |
+
+### Returns
+
+| Type   | Description     |
+| -----  | --------------- |
+| string | The extracted string, or an empty string if no match was found |
+
+
+### Example
+
+<CodeGroup labels={[]}>
+
+```javascript
+import { findBetween } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+
+export default function() {
+  const response = '<div class="message">Login successful!</div>';
+
+  const message = findBetween(response, '<div class="message">', '</div>');
+
+  console.log(message); // Login successful!
+}
+```
+
+</CodeGroup>

--- a/src/data/markdown/docs/02 javascript api/11 jslib/utils/05 findBetween(content, left, right).md
+++ b/src/data/markdown/docs/02 javascript api/11 jslib/utils/05 findBetween(content, left, right).md
@@ -24,7 +24,7 @@ Function that returns a string from between two other strings.
 <CodeGroup labels={[]}>
 
 ```javascript
-import { findBetween } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+import { findBetween } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 export default function() {
   const response = '<div class="message">Login successful!</div>';

--- a/src/data/markdown/docs/05 Examples/01 Examples/19 functional testing.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/19 functional testing.md
@@ -45,7 +45,7 @@ This test goes through several steps. It creates a new user account, authenticat
 ```javascript
 import { describe } from 'https://jslib.k6.io/functional/0.0.3/index.js';
 import { Httpx, Request, Get, Post } from 'https://jslib.k6.io/httpx/0.0.2/index.js';
-import { randomIntBetween, randomItem } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+import { randomIntBetween, randomItem } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 export let options = {
   thresholds: {

--- a/src/data/markdown/translated-guides/en/02 Using k6/07 Modules.md
+++ b/src/data/markdown/translated-guides/en/02 Using k6/07 Modules.md
@@ -54,7 +54,7 @@ runtime, making it extremely important to **make sure the code is legit and trus
 it in a test script**.
 
 ```javascript
-import { randomItem } from 'https://jslib.k6.io/k6-utils/1.0.0/index.js';
+import { randomItem } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 
 export default function () {
   randomItem();

--- a/src/data/markdown/translated-guides/es/02 Using k6/07 Modules.md
+++ b/src/data/markdown/translated-guides/es/02 Using k6/07 Modules.md
@@ -46,7 +46,7 @@ export default function () {
 Se accede a estos módulos a través de HTTP(S), desde una fuente como el [k6 JSLib](#the-jslib-repository) o desde cualquier servidor web de acceso público. Los módulos importados serán descargados y ejecutados en tiempo de ejecución, por lo que es extremadamente importante asegurarse de que el código es legítimo y de confianza antes de incluirlo en un script de prueba.
 
 ```javascript
-import { randomItem } from 'https://jslib.k6.io/k6-utils/1.0.0/index.js';
+import { randomItem } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
 
 export default function () {
   randomItem();


### PR DESCRIPTION
I've added a new page for `findBetween` but I'm not sure whether that will automatically resolve to the link `/javascript-api/jslib/utils/findbetween`.