### PR TITLE
doc(02 javascript api): add missing imports(sleep)

### DIFF
--- a/src/data/markdown/docs/02 javascript api/09 k6-net-grpc.md
+++ b/src/data/markdown/docs/02 javascript api/09 k6-net-grpc.md
@@ -28,7 +28,7 @@ The k6 gRPC API is currently considered in beta and is subject to change. Future
 
 ```javascript
 import grpc from 'k6/net/grpc';
-import { check } from 'k6';
+import { check, sleep } from 'k6';
 
 const client = new grpc.Client();
 client.load(['definitions'], 'hello.proto');


### PR DESCRIPTION
In the GRPC example, the part that does not work if we follow the guide in the document has been fixed.

Target doc: https://k6.io/docs/javascript-api/k6-net-grpc


```diff
import grpc from 'k6/net/grpc';
- import { check } from 'k6';
+ import { check, sleep } from 'k6';

const client = new grpc.Client();
client.load(['definitions'], 'hello.proto');

export default () => {
  client.connect('grpcb.in:9001', {
    // plaintext: false
  });

  const data = { greeting: 'Bert' };
  const response = client.invoke('hello.HelloService/SayHello', data);

  check(response, {
    'status is OK': (r) => r && r.status === grpc.StatusOK,
  });

  console.log(JSON.stringify(response.message));

  client.close();
  sleep(1);
};

```
