### PR TITLE
feat: add https://github.com/szkiba/xk6-cache extension

### DIFF
--- a/src/data/ecosystem/extensions.js
+++ b/src/data/ecosystem/extensions.js
@@ -423,7 +423,7 @@ const extensions = [
   {
     name: 'xk6-cache',
     description:
-      'A k6 extension enables vendoring remote HTTP modules to single source control friendly file.',
+      'A k6 extension that enables vendoring remote HTTP modules to a single source control friendly file.',
     url: 'https://github.com/szkiba/xk6-cache',
     logo: '',
     author: {

--- a/src/data/ecosystem/extensions.js
+++ b/src/data/ecosystem/extensions.js
@@ -420,6 +420,19 @@ const extensions = [
     official: false,
     categories: ['Reporting', 'Observability'],
   },
+  {
+    name: 'xk6-cache',
+    description: 
+      'A k6 extension enables vendoring remote HTTP modules to single source control friendly file.',
+    url: 'https://github.com/szkiba/xk6-cache',
+    logo: '',
+    author: {
+      name: 'Iván Szkiba',
+      url: 'https://github.com/szkiba',
+    },
+    official: false,
+    categories: ['Misc'],
+  },
 ];
 
 export default extensions;

--- a/src/data/ecosystem/extensions.js
+++ b/src/data/ecosystem/extensions.js
@@ -22,8 +22,7 @@ const extensions = [
     name: 'xk6-kafka',
     description: 'Load test Apache Kafka. With support for Avro messages',
     url: 'https://github.com/mostafa/xk6-kafka',
-    logo:
-      'https://github.com/mostafa/xk6-kafka/blob/1259557afd378a5fe236e19c3d09bda401584ee6/assets/kafka-logo.png?raw=true',
+    logo: 'https://github.com/mostafa/xk6-kafka/blob/1259557afd378a5fe236e19c3d09bda401584ee6/assets/kafka-logo.png?raw=true',
     author: {
       name: 'Mostafa Moradian',
       url: 'https://github.com/mostafa',
@@ -35,8 +34,7 @@ const extensions = [
     name: 'xk6-notification',
     description: 'A k6 extension for creating notifications.',
     url: 'https://github.com/dgzlopes/xk6-notification',
-    logo:
-      'https://github.com/dgzlopes/xk6-notification/blob/db5504667ff7530ee619c42e5c1037703f603b30/assets/logo.png?raw=true',
+    logo: 'https://github.com/dgzlopes/xk6-notification/blob/db5504667ff7530ee619c42e5c1037703f603b30/assets/logo.png?raw=true',
     author: {
       name: 'Daniel González',
       url: 'https://github.com/dgzlopes',
@@ -48,8 +46,7 @@ const extensions = [
     name: 'xk6-chaos',
     description: 'xk6 extension for running chaos experiments with k6 💣',
     url: 'https://github.com/simskij/xk6-chaos',
-    logo:
-      'https://github.com/simskij/xk6-chaos/blob/064932e0bae64fe94de2f86bf3c41be18fbab1d6/assets/logo.png?raw=true',
+    logo: 'https://github.com/simskij/xk6-chaos/blob/064932e0bae64fe94de2f86bf3c41be18fbab1d6/assets/logo.png?raw=true',
     isLogoLarge: true,
     author: {
       name: 'Simon Aronsson',
@@ -422,7 +419,7 @@ const extensions = [
   },
   {
     name: 'xk6-cache',
-    description: 
+    description:
       'A k6 extension enables vendoring remote HTTP modules to single source control friendly file.',
     url: 'https://github.com/szkiba/xk6-cache',
     logo: '',

--- a/src/data/ecosystem/extensions.js
+++ b/src/data/ecosystem/extensions.js
@@ -422,7 +422,7 @@ const extensions = [
   },
   {
     name: 'xk6-cache',
-    description: 
+    description:
       'A k6 extension enables vendoring remote HTTP modules to single source control friendly file.',
     url: 'https://github.com/szkiba/xk6-cache',
     logo: '',

--- a/src/data/ecosystem/extensions.js
+++ b/src/data/ecosystem/extensions.js
@@ -22,7 +22,8 @@ const extensions = [
     name: 'xk6-kafka',
     description: 'Load test Apache Kafka. With support for Avro messages',
     url: 'https://github.com/mostafa/xk6-kafka',
-    logo: 'https://github.com/mostafa/xk6-kafka/blob/1259557afd378a5fe236e19c3d09bda401584ee6/assets/kafka-logo.png?raw=true',
+    logo:
+      'https://github.com/mostafa/xk6-kafka/blob/1259557afd378a5fe236e19c3d09bda401584ee6/assets/kafka-logo.png?raw=true',
     author: {
       name: 'Mostafa Moradian',
       url: 'https://github.com/mostafa',
@@ -34,7 +35,8 @@ const extensions = [
     name: 'xk6-notification',
     description: 'A k6 extension for creating notifications.',
     url: 'https://github.com/dgzlopes/xk6-notification',
-    logo: 'https://github.com/dgzlopes/xk6-notification/blob/db5504667ff7530ee619c42e5c1037703f603b30/assets/logo.png?raw=true',
+    logo:
+      'https://github.com/dgzlopes/xk6-notification/blob/db5504667ff7530ee619c42e5c1037703f603b30/assets/logo.png?raw=true',
     author: {
       name: 'Daniel González',
       url: 'https://github.com/dgzlopes',
@@ -46,7 +48,8 @@ const extensions = [
     name: 'xk6-chaos',
     description: 'xk6 extension for running chaos experiments with k6 💣',
     url: 'https://github.com/simskij/xk6-chaos',
-    logo: 'https://github.com/simskij/xk6-chaos/blob/064932e0bae64fe94de2f86bf3c41be18fbab1d6/assets/logo.png?raw=true',
+    logo:
+      'https://github.com/simskij/xk6-chaos/blob/064932e0bae64fe94de2f86bf3c41be18fbab1d6/assets/logo.png?raw=true',
     isLogoLarge: true,
     author: {
       name: 'Simon Aronsson',
@@ -419,7 +422,7 @@ const extensions = [
   },
   {
     name: 'xk6-cache',
-    description:
+    description: 
       'A k6 extension enables vendoring remote HTTP modules to single source control friendly file.',
     url: 'https://github.com/szkiba/xk6-cache',
     logo: '',


### PR DESCRIPTION
[xk6-cache](https://github.com/szkiba/xk6-cache) enables vendoring [Remote HTTP(s) modules](https://k6.io/docs/using-k6/modules#remote-http-s-modules) to single source control friendly file.