### PR TITLE
add xk6-mock to ecosystem page

### DIFF
--- a/src/data/ecosystem/extensions.js
+++ b/src/data/ecosystem/extensions.js
@@ -433,6 +433,18 @@ const extensions = [
     official: false,
     categories: ['Misc'],
   },
+  {
+    name: 'xk6-mock',
+    description: 'A k6 extension that enables mocking HTTP(S) servers.',
+    url: 'https://github.com/szkiba/xk6-mock',
+    logo: '',
+    author: {
+      name: 'Iván Szkiba',
+      url: 'https://github.com/szkiba',
+    },
+    official: false,
+    categories: ['Misc'],
+  },
 ];
 
 export default extensions;


### PR DESCRIPTION
[xk6-mock](https://github.com/szkiba/xk6-mock) is a k6 extension for mocking HTTP(S) servers.