### PR TITLE
[WIP] Prev/next article links

### DIFF
--- a/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.module.scss
+++ b/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.module.scss
@@ -1,0 +1,60 @@
+.wrapper {
+  display: flex;
+  justify-content: space-between;
+
+  max-width: calc(100% - 325px);
+  margin: 15px 0 50px;
+  @include lg-down {
+    max-width: calc(100% - 240px);
+    flex-flow: column-reverse;
+  }
+  @include md-down {
+    max-width: 100%;
+  }
+}
+
+.item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  padding-right: 36px;
+  margin-left: auto;
+
+  text-decoration: none;
+  color: $color-primary;
+
+  & svg {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    right: 0;
+  }
+
+  &.prev {
+    margin-left: 0;
+    margin-right: auto;
+    padding-right: 0;
+    padding-left: 36px;
+    & svg {
+      transform: rotate(180deg) translateY(50%);
+      right: auto;
+      left: 0;
+    }
+  }
+
+  &:hover {
+    .name {
+      color: $color-accent-primary;
+      transition: 0.3s;
+    }
+  }
+}
+
+.direction {
+  font-weight: 700;
+  font-size: $font-size-xs;
+  line-height: $line-height-xs;
+  color: $color-accent-primary;
+  text-transform: uppercase;
+}

--- a/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.module.scss
+++ b/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.module.scss
@@ -7,10 +7,17 @@
   max-width: calc(100% - 325px);
 
   @include lg-down {
-    max-width: calc(100% - 240px);
+    max-width: 100%;
   }
   @include md-down {
     max-width: 100%;
+  }
+
+  @include xs-down {
+    flex-direction: column;
+    & > *:first-child {
+      margin-bottom: 30px;
+    }
   }
 
   &.top-level {
@@ -25,7 +32,7 @@
   align-items: flex-end;
   flex-direction: column;
   cursor: pointer;
-  padding-right: 36px;
+  padding-right: 32px;
   margin-left: auto;
 
   text-decoration: none;
@@ -43,7 +50,7 @@
     margin-left: 0;
     margin-right: auto;
     padding-right: 0;
-    padding-left: 36px;
+    padding-left: 32px;
     & svg {
       transform: rotate(180deg) translateY(50%);
       right: auto;

--- a/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.module.scss
+++ b/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.module.scss
@@ -1,21 +1,28 @@
 .wrapper {
+  margin-top: -10px;
+  padding-bottom: 50px;
   display: flex;
   justify-content: space-between;
 
   max-width: calc(100% - 325px);
-  margin: 15px 0 50px;
+
   @include lg-down {
     max-width: calc(100% - 240px);
-    flex-flow: column-reverse;
   }
   @include md-down {
     max-width: 100%;
+  }
+
+  &.top-level {
+    margin-top: 50px;
+    padding-bottom: 0;
   }
 }
 
 .item {
   position: relative;
   display: flex;
+  align-items: flex-end;
   flex-direction: column;
   cursor: pointer;
   padding-right: 36px;
@@ -32,6 +39,7 @@
   }
 
   &.prev {
+    align-items: flex-start;
     margin-left: 0;
     margin-right: auto;
     padding-right: 0;

--- a/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.view.js
+++ b/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.view.js
@@ -1,0 +1,27 @@
+import classNames from 'classnames/bind';
+import { Link } from 'gatsby';
+import React from 'react';
+import Chevron from 'svg/chevron.inline.svg';
+
+import styles from './doc-page-navigation.module.scss';
+
+const cx = classNames.bind(styles);
+
+const NavigationButton = ({ type, title, path }) => (
+  <Link className={cx('item', type === 'next' ? 'next' : 'prev')} to={path}>
+    <Chevron />
+    <span className={styles.direction}>{type}</span>
+    <span className={styles.name}>{title}</span>
+  </Link>
+);
+
+export const DocPageNavigation = ({ prev, next }) => (
+  <div className={styles.wrapper}>
+    {prev && (
+      <NavigationButton type="previous" title={prev.title} path={prev.path} />
+    )}
+    {next && (
+      <NavigationButton type="next" title={next.title} path={next.path} />
+    )}
+  </div>
+);

--- a/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.view.js
+++ b/src/components/pages/doc-page/doc-page-navigation/doc-page-navigation.view.js
@@ -15,8 +15,8 @@ const NavigationButton = ({ type, title, path }) => (
   </Link>
 );
 
-export const DocPageNavigation = ({ prev, next }) => (
-  <div className={styles.wrapper}>
+export const DocPageNavigation = ({ prev, next, variant = 'default' }) => (
+  <div className={cx('wrapper', variant === 'top-level' && 'top-level')}>
     {prev && (
       <NavigationButton type="previous" title={prev.title} path={prev.path} />
     )}

--- a/src/components/pages/doc-page/doc-page-navigation/index.js
+++ b/src/components/pages/doc-page/doc-page-navigation/index.js
@@ -1,0 +1,1 @@
+export { DocPageNavigation } from './doc-page-navigation.view';

--- a/src/svg/chevron.inline.svg
+++ b/src/svg/chevron.inline.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="18" viewBox="0 0 10 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M1 1L9 9L1 17" stroke="#3C3C64" />
+</svg>

--- a/src/templates/doc-page.js
+++ b/src/templates/doc-page.js
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { DocPageNavigation } from 'components/pages/doc-page/doc-page-navigation';
 import { DocPageTitleGroup } from 'components/pages/doc-page/doc-page-title-group';
 import { styles as codeStyles } from 'components/shared/code';
 import { Breadcrumbs } from 'components/templates/doc-page/breadcrumbs';
@@ -9,6 +10,29 @@ import { useScrollToAnchor } from 'hooks';
 import { DocLayout } from 'layouts/doc-layout';
 import React from 'react';
 import { LATEST_VERSION } from 'utils/utils.node';
+
+const flattenTree = (sidebar) => {
+  const flat = [];
+  const processNode = (node) => {
+    if (node.children) {
+      const keys = Object.keys(node.children);
+      keys.forEach((key) => {
+        if (node.children[key].meta.hideFromSidebar) {
+          return;
+        }
+        flat.push({
+          title: node.children[key].meta.title,
+          path: node.children[key].meta.path,
+        });
+        processNode(node.children[key]);
+      });
+    }
+  };
+
+  const keys = Object.keys(sidebar.children);
+  keys.forEach((key) => processNode(sidebar.children[key]));
+  return flat;
+};
 
 export default function (props) {
   const {
@@ -36,6 +60,27 @@ export default function (props) {
   const isJsAPIPage =
     sidebarTree.name === 'javascript api' || typeof version !== 'undefined';
 
+  let prev = null;
+  let next = null;
+
+  if (
+    sidebarTree.name === 'cloud' ||
+    sidebarTree.name === 'es' ||
+    sidebarTree.name === 'en'
+  ) {
+    const flatSidebar = flattenTree(sidebarTree);
+    const currentIndex = flatSidebar.findIndex(
+      (elem) => elem.path === `/${frontmatter.slug}`,
+    );
+
+    if (currentIndex > 0) {
+      prev = flatSidebar[currentIndex - 1];
+    }
+    if (currentIndex < flatSidebar.length - 1) {
+      next = flatSidebar[currentIndex + 1];
+    }
+  }
+
   return (
     <LocaleProvider urlLocale={locale}>
       <DocLayout
@@ -46,7 +91,7 @@ export default function (props) {
         locale={locale}
         version={isJsAPIPage ? version || LATEST_VERSION : null}
         pageVersions={pageVersions}
-        path={path}
+        path={frontmatter.slug}
       >
         <div
           className={classNames(
@@ -60,6 +105,7 @@ export default function (props) {
             articleSrc={frontmatter.fileOrigin}
           />
           <DocPageContent label={codeStyles.codeContainer} content={body} />
+          {(prev || next) && <DocPageNavigation prev={prev} next={next} />}
         </div>
       </DocLayout>
     </LocaleProvider>

--- a/src/templates/doc-page.js
+++ b/src/templates/doc-page.js
@@ -9,30 +9,8 @@ import LocaleProvider from 'contexts/locale-provider';
 import { useScrollToAnchor } from 'hooks';
 import { DocLayout } from 'layouts/doc-layout';
 import React from 'react';
+import { flattenSidebarTree } from 'utils/utils';
 import { LATEST_VERSION } from 'utils/utils.node';
-
-const flattenTree = (sidebar) => {
-  const flat = [];
-  const processNode = (node) => {
-    if (node.children) {
-      const keys = Object.keys(node.children);
-      keys.forEach((key) => {
-        if (node.children[key].meta.hideFromSidebar) {
-          return;
-        }
-        flat.push({
-          title: node.children[key].meta.title,
-          path: node.children[key].meta.path,
-        });
-        processNode(node.children[key]);
-      });
-    }
-  };
-
-  const keys = Object.keys(sidebar.children);
-  keys.forEach((key) => processNode(sidebar.children[key]));
-  return flat;
-};
 
 export default function (props) {
   const {
@@ -63,12 +41,13 @@ export default function (props) {
   let prev = null;
   let next = null;
 
+  // only get prev and next articles for Guides and Cloud sections
   if (
     sidebarTree.name === 'cloud' ||
     sidebarTree.name === 'es' ||
     sidebarTree.name === 'en'
   ) {
-    const flatSidebar = flattenTree(sidebarTree);
+    const flatSidebar = flattenSidebarTree(sidebarTree);
     const currentIndex = flatSidebar.findIndex(
       (elem) => elem.path === `/${frontmatter.slug}`,
     );

--- a/src/templates/doc-page.js
+++ b/src/templates/doc-page.js
@@ -55,6 +55,12 @@ export default function (props) {
     if (currentIndex > 0) {
       prev = flatSidebar[currentIndex - 1];
     }
+    if (currentIndex === 0 && sidebarTree.name === 'cloud') {
+      prev = {
+        title: 'Cloud docs',
+        path: '/cloud/',
+      };
+    }
     if (currentIndex < flatSidebar.length - 1) {
       next = flatSidebar[currentIndex + 1];
     }

--- a/src/templates/doc-page.js
+++ b/src/templates/doc-page.js
@@ -61,7 +61,7 @@ export default function (props) {
         path: '/cloud/',
       };
     }
-    if (currentIndex < flatSidebar.length - 1) {
+    if (currentIndex < flatSidebar.length - 1 && currentIndex > 0) {
       next = flatSidebar[currentIndex + 1];
     }
   }

--- a/src/templates/docs/cloud.js
+++ b/src/templates/docs/cloud.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import htmlStyles from 'components/blocks/html-content/html-content.module.scss';
+import { DocPageNavigation } from 'components/pages/doc-page/doc-page-navigation';
 import TableOfContents from 'components/pages/doc-page/table-of-contents';
 import { CtaDoc } from 'components/shared/cta-doc';
 import { PageInfo } from 'components/shared/page-info';
@@ -14,6 +15,7 @@ import { StickyContainer, Sticky } from 'react-sticky';
 import { isInIFrame } from 'utils';
 import SeoMetadata from 'utils/seo-metadata';
 import { app } from 'utils/urls';
+import { flattenSidebarTree } from 'utils/utils';
 
 export default function ({ pageContext: { sidebarTree, navLinks } }) {
   const [showFooter, setShowFooter] = useState(true);
@@ -27,6 +29,8 @@ export default function ({ pageContext: { sidebarTree, navLinks } }) {
     docPageContent.mainDocContent,
     docPageContent.contentWrapper,
   );
+
+  const flatSidebar = flattenSidebarTree(sidebarTree);
 
   return (
     <LocaleProvider>
@@ -237,6 +241,11 @@ export default function ({ pageContext: { sidebarTree, navLinks } }) {
                 />
               )}
             </div>
+            <DocPageNavigation
+              prev={null}
+              next={flatSidebar[0]}
+              variant="top-level"
+            />
             <Sticky topOffset={-15} bottomOffset={0} disableCompensation>
               {({ style }) => (
                 <TableOfContents

--- a/src/templates/docs/guides.js
+++ b/src/templates/docs/guides.js
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { DocPageNavigation } from 'components/pages/doc-page/doc-page-navigation';
 import TableOfContents from 'components/pages/doc-page/table-of-contents';
 import {
   Cloud,
@@ -19,6 +20,7 @@ import React, { useRef } from 'react';
 import { Sticky, StickyContainer } from 'react-sticky';
 import SeoMetadata from 'utils/seo-metadata';
 import { docs } from 'utils/urls';
+import { flattenSidebarTree } from 'utils/utils';
 
 const pageInfo = {
   en: {
@@ -64,6 +66,8 @@ function GuidesContent({
     },
   };
 
+  const flatSidebar = flattenSidebarTree(sidebarTree);
+
   return (
     <DocLayout
       sidebarTree={sidebarTree}
@@ -95,6 +99,11 @@ function GuidesContent({
               />
             )}
           </div>
+          <DocPageNavigation
+            prev={null}
+            next={flatSidebar[1]}
+            variant="top-level"
+          />
 
           <Sticky topOffset={-15} bottomOffset={10} disableCompensation>
             {({ style }) => (

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -6,9 +6,7 @@ const { latinizedCharacters } = require('./latinized-characters');
 // container for default export (node-specific action)
 const utils = {};
 
-const capitalize = (str) => {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-};
+const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
 
 const omit = (names, obj) => {
   const result = {};
@@ -180,6 +178,32 @@ const mdxAstToPlainText = (ast) => {
   return $toString(ast);
 };
 
+/* returns preorder traversal of sidebar tree,
+ignores top-level children and hidden pages */
+const flattenSidebarTree = (sidebar) => {
+  const flatTree = [];
+  const processNode = (node) => {
+    if (node.children) {
+      const keys = Object.keys(node.children);
+      keys.forEach((key) => {
+        // ignore pages that are hidden from sidebar
+        if (node.children[key].meta.hideFromSidebar) {
+          return;
+        }
+        flatTree.push({
+          title: node.children[key].meta.title,
+          path: node.children[key].meta.path,
+        });
+        processNode(node.children[key]);
+      });
+    }
+  };
+
+  const keys = Object.keys(sidebar.children);
+  keys.forEach((key) => processNode(sidebar.children[key]));
+  return flatTree;
+};
+
 // es5 tricky alternative to .flat
 // !warninng: support only 1 level deep
 // eslint-disable-next-line prefer-spread
@@ -230,6 +254,9 @@ Object.defineProperties(utils, {
   },
   capitalize: {
     value: capitalize,
+  },
+  flattenSidebarTree: {
+    value: flattenSidebarTree,
   },
 });
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -187,7 +187,10 @@ const flattenSidebarTree = (sidebar) => {
       const keys = Object.keys(node.children);
       keys.forEach((key) => {
         // ignore pages that are hidden from sidebar
-        if (node.children[key].meta.hideFromSidebar) {
+        if (
+          node.children[key].meta.hideFromSidebar ||
+          node.children[key].meta.redirect
+        ) {
           return;
         }
         flatTree.push({


### PR DESCRIPTION
This PR adds links to previous and next articles for all pages in Guides and Cloud sections that are accessible from the sidebar.

**Screenshot**
![image](https://user-images.githubusercontent.com/10406201/121031677-3cea6600-c7b3-11eb-93b7-a075c5798c6f.png)

**TODO**
[] handle redirects
